### PR TITLE
Update FoldingScheme trait to take C1 & C2 as params

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ ark-poly = "0.4.0"
 ark-crypto-primitives = { version = "^0.4.0", default-features = false, features = [ "r1cs", "sponge" ] }
 ark-relations = { version = "^0.4.0", default-features = false }
 ark-r1cs-std = { version = "^0.4.0", default-features = false }
+thiserror = "1.0" 
 
 [dev-dependencies]
 ark-bls12-381 = "0.4.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,7 +29,11 @@ pub trait Transcript<F: PrimeField> {
 /// - C1 is the main curve, which ScalarField we use as our F for al the field operations
 /// - C2 is the auxiliary curve, which we use for the commitments, whose BaseField (for point
 /// coordinates) are in the C1::ScalarField
-pub trait FoldingScheme<C1: CurveGroup, C2: CurveGroup>: Clone + Debug {
+pub trait FoldingScheme<C1: CurveGroup, C2: CurveGroup>: Clone + Debug
+where
+    C1: CurveGroup<BaseField = C2::ScalarField, ScalarField = C2::BaseField>,
+    C2::BaseField: PrimeField,
+{
     // type PCS: PolynomialCommitmentScheme<C>; // maybe not needed, just PedersenCommitment
     type PreprocessorParam: Debug;
     type ProverParam: Debug;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,11 +1,18 @@
+#![allow(non_snake_case)]
+#![allow(non_upper_case_globals)]
+
 use ark_ec::CurveGroup;
 use ark_ff::PrimeField;
 use ark_std::{fmt::Debug, rand::RngCore};
+use thiserror::Error;
 
 pub mod transcript;
 
-#[derive(Debug)]
-pub enum Error {}
+#[derive(Debug, Error)]
+pub enum Error {
+    #[error("Relation not satisfied")]
+    NotSatisfied,
+}
 
 pub trait Transcript<F: PrimeField> {
     type TranscriptConfig: Debug;
@@ -17,7 +24,12 @@ pub trait Transcript<F: PrimeField> {
     fn get_challenges(&mut self, n: usize) -> Vec<F>;
 }
 
-pub trait FoldingScheme<C: CurveGroup>: Clone + Debug {
+/// FoldingScheme defines trait that is implemented by the diverse folding schemes. It is defined
+/// over a cycle of curves (C1, C2), where:
+/// - C1 is the main curve, which ScalarField we use as our F for al the field operations
+/// - C2 is the auxiliary curve, which we use for the commitments, whose BaseField (for point
+/// coordinates) are in the C1::ScalarField
+pub trait FoldingScheme<C1: CurveGroup, C2: CurveGroup>: Clone + Debug {
     // type PCS: PolynomialCommitmentScheme<C>; // maybe not needed, just PedersenCommitment
     type PreprocessorParam: Debug;
     type ProverParam: Debug;
@@ -40,7 +52,7 @@ pub trait FoldingScheme<C: CurveGroup>: Clone + Debug {
         pp: &Self::ProverParam,
         running_instance: &mut Self::CommittedInstanceWithWitness,
         incomming_instances: &[Self::FreshInstance],
-        transcript: &mut impl Transcript<C::ScalarField>,
+        transcript: &mut impl Transcript<C1::ScalarField>,
         rng: impl RngCore,
     ) -> Result<(), Error>;
 
@@ -48,7 +60,7 @@ pub trait FoldingScheme<C: CurveGroup>: Clone + Debug {
         vp: &Self::VerifierParam,
         running_instance: &mut Self::CommittedInstance,
         incomming_instances: &[Self::PublicInput],
-        transcript: &mut impl Transcript<C::ScalarField>,
+        transcript: &mut impl Transcript<C1::ScalarField>,
         rng: impl RngCore,
     ) -> Result<(), Error>;
 }


### PR DESCRIPTION
Update FoldingScheme trait to take C1 & C2 as params which are used by the diverse folding schemes as a cycle of curves.