### PR TITLE
impl hash committed instance gadget (#17)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ ark-ec = "0.4.2"
 ark-ff = "^0.4.0"
 ark-poly = "^0.4.0"
 ark-std = "^0.4.0"
-ark-crypto-primitives = { version = "^0.4.0", default-features = false, features = ["r1cs", "sponge"] }
+ark-crypto-primitives = { version = "^0.4.0", default-features = false, features = ["r1cs", "sponge", "crh"] }
 ark-relations = { version = "^0.4.0", default-features = false }
 ark-r1cs-std = { version = "^0.4.0", default-features = false }
 thiserror = "1.0"
@@ -23,7 +23,6 @@ espresso_transcript = {git="https://github.com/EspressoSystems/hyperplonk", pack
 [dev-dependencies]
 ark-pallas = {version="0.4.0", features=["r1cs"]}
 ark-vesta = {version="0.4.0"}
-ark-crypto-primitives = { version = "^0.4.0", default-features = false, features = ["crh"] }
 
 [features]
 default = ["parallel", "nova", "hypernova"]

--- a/src/folding/circuits/mod.rs
+++ b/src/folding/circuits/mod.rs
@@ -3,6 +3,7 @@ use ark_ec::CurveGroup;
 use ark_ff::Field;
 
 pub mod cyclefold;
+pub mod nonnative;
 
 // CF represents the constraints field
 pub type CF<C> = <<C as CurveGroup>::BaseField as Field>::BasePrimeField;

--- a/src/folding/circuits/nonnative.rs
+++ b/src/folding/circuits/nonnative.rs
@@ -1,0 +1,71 @@
+use ark_ec::{AffineRepr, CurveGroup};
+use ark_ff::PrimeField;
+use ark_r1cs_std::fields::nonnative::{params::OptimizationType, AllocatedNonNativeFieldVar};
+use ark_r1cs_std::{
+    alloc::{AllocVar, AllocationMode},
+    fields::nonnative::NonNativeFieldVar,
+};
+use ark_relations::r1cs::{Namespace, SynthesisError};
+use core::borrow::Borrow;
+
+/// NonNativeAffineVar represents an elliptic curve point in Affine represenation in the non-native
+/// field. It is not intended to perform operations, but just to contain the affine coordinates in
+/// order to perform hash operations of the point.
+#[derive(Debug, Clone)]
+pub struct NonNativeAffineVar<F: PrimeField, CF: PrimeField> {
+    pub x: NonNativeFieldVar<F, CF>,
+    pub y: NonNativeFieldVar<F, CF>,
+}
+
+impl<C> AllocVar<C, C::ScalarField> for NonNativeAffineVar<C::BaseField, C::ScalarField>
+where
+    C: CurveGroup,
+    <C as ark_ec::CurveGroup>::BaseField: ark_ff::PrimeField,
+{
+    fn new_variable<T: Borrow<C>>(
+        cs: impl Into<Namespace<C::ScalarField>>,
+        f: impl FnOnce() -> Result<T, SynthesisError>,
+        mode: AllocationMode,
+    ) -> Result<Self, SynthesisError> {
+        f().and_then(|val| {
+            let cs = cs.into();
+
+            let affine = val.borrow().into_affine();
+            let xy = affine.xy().unwrap();
+            let x = NonNativeFieldVar::<C::BaseField, C::ScalarField>::new_variable(
+                cs.clone(),
+                || Ok(xy.0),
+                mode,
+            )?;
+            let y = NonNativeFieldVar::<C::BaseField, C::ScalarField>::new_variable(
+                cs.clone(),
+                || Ok(xy.1),
+                mode,
+            )?;
+
+            Ok(Self { x, y })
+        })
+    }
+}
+
+/// point_to_nonnative_limbs is used to return (outside the circuit) the limbs representation that
+/// matches the one used in-circuit.
+#[allow(clippy::type_complexity)]
+pub fn point_to_nonnative_limbs<C: CurveGroup>(
+    p: C,
+) -> Result<(Vec<C::ScalarField>, Vec<C::ScalarField>), SynthesisError>
+where
+    <C as ark_ec::CurveGroup>::BaseField: ark_ff::PrimeField,
+{
+    let affine = p.into_affine();
+    let (x, y) = affine.xy().unwrap();
+    let x = AllocatedNonNativeFieldVar::<C::BaseField, C::ScalarField>::get_limbs_representations(
+        x,
+        OptimizationType::Weight,
+    )?;
+    let y = AllocatedNonNativeFieldVar::<C::BaseField, C::ScalarField>::get_limbs_representations(
+        y,
+        OptimizationType::Weight,
+    )?;
+    Ok((x, y))
+}

--- a/src/folding/nova/mod.rs
+++ b/src/folding/nova/mod.rs
@@ -1,10 +1,15 @@
 /// Implements the scheme described in [Nova](https://eprint.iacr.org/2021/370.pdf)
-use ark_crypto_primitives::sponge::Absorb;
+use ark_crypto_primitives::{
+    crh::{poseidon::CRH, CRHScheme},
+    sponge::{poseidon::PoseidonConfig, Absorb},
+};
 use ark_ec::{CurveGroup, Group};
 use ark_std::fmt::Debug;
 use ark_std::{One, Zero};
 
+use crate::folding::circuits::nonnative::point_to_nonnative_limbs;
 use crate::pedersen::{Params as PedersenParams, Pedersen};
+use crate::Error;
 
 pub mod circuits;
 pub mod nifs;
@@ -17,7 +22,11 @@ pub struct CommittedInstance<C: CurveGroup> {
     pub x: Vec<C::ScalarField>,
 }
 
-impl<C: CurveGroup> CommittedInstance<C> {
+impl<C: CurveGroup> CommittedInstance<C>
+where
+    <C as Group>::ScalarField: Absorb,
+    <C as ark_ec::CurveGroup>::BaseField: ark_ff::PrimeField,
+{
     pub fn empty() -> Self {
         CommittedInstance {
             cmE: C::zero(),
@@ -25,6 +34,35 @@ impl<C: CurveGroup> CommittedInstance<C> {
             cmW: C::zero(),
             x: Vec::new(),
         }
+    }
+
+    /// hash implements the committed instance hash compatible with the gadget implemented in
+    /// nova/circuits.rs::CommittedInstanceVar.hash.
+    /// Returns `H(i, z_0, z_i, U_i)`, where `i` can be `i` but also `i+1`, and `U` is the
+    /// `CommittedInstance`.
+    pub fn hash(
+        &self,
+        poseidon_config: &PoseidonConfig<C::ScalarField>,
+        i: C::ScalarField,
+        z_0: C::ScalarField,
+        z_i: C::ScalarField,
+    ) -> Result<C::ScalarField, Error> {
+        let (cmE_x, cmE_y) = point_to_nonnative_limbs::<C>(self.cmE)?;
+        let (cmW_x, cmW_y) = point_to_nonnative_limbs::<C>(self.cmW)?;
+
+        Ok(CRH::<C::ScalarField>::evaluate(
+            poseidon_config,
+            vec![
+                vec![i, z_0, z_i, self.u],
+                self.x.clone(),
+                cmE_x,
+                cmE_y,
+                cmW_x,
+                cmW_y,
+            ]
+            .concat(),
+        )
+        .unwrap())
     }
 }
 


### PR DESCRIPTION
resolves #17 

Implements natively and in-circuit the committed instances hashes which are used as:

$$\mathsf{u}_i.X \stackrel{?}{=} H(vk, i, z_0, z_i, \mathsf{U}_i)$$

$$\mathsf{U}_{i+1}.X \leftarrow H(vk, i+1, z_0, z _{i+1} , U _{i+1} )$$

taking as inputs $j, z_0, z_j, U_j$ for $j \in \{i, i+1\}$.