### PR TITLE
update RelaxedR1CSGadget to work with FieldVar trait so we can plug in FpVar and NonNativeFieldVar indistinctly

### DIFF
--- a/src/folding/nova/cyclefold.rs
+++ b/src/folding/nova/cyclefold.rs
@@ -386,6 +386,7 @@ where
         // the CycleFoldCircuit are the sames used in the public inputs 'x', which come from the
         // AugmentedFCircuit.
         // TODO: Issue to keep track of this: https://github.com/privacy-scaling-explorations/folding-schemes/issues/44
+        // and https://github.com/privacy-scaling-explorations/folding-schemes/issues/48
 
         Ok(())
     }


### PR DESCRIPTION
This is to be able to instantiate the CycleFoldCircuit over Curve2 constraint field, and check it's RelaxedR1CS relation non-natively inside the Curve1 constraint field, while reusing the same code that we already have for checking the main circuit RelaxedR1CS over Curve1 constraint field natively.