### PR TITLE
Add CommitmentProver trait, and add KZG prover to it

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,6 @@ thiserror = "1.0"
 rayon = "1.7.0"
 num-bigint = "0.4"
 color-eyre = "=0.6.2"
-derivative = { version = "2", features = [ "use_core" ] }
 
 # tmp imports for espresso's sumcheck
 espresso_subroutines = {git="https://github.com/EspressoSystems/hyperplonk", package="subroutines"}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ ark-ff = "^0.4.0"
 ark-poly = "^0.4.0"
 ark-std = "^0.4.0"
 ark-crypto-primitives = { version = "^0.4.0", default-features = false, features = ["r1cs", "sponge", "crh"] }
+ark-poly-commit = "^0.4.0"
 ark-relations = { version = "^0.4.0", default-features = false }
 ark-r1cs-std = { default-features = false } # use latest version from the patch
 ark-serialize = "^0.4.0"
@@ -17,6 +18,7 @@ thiserror = "1.0"
 rayon = "1.7.0"
 num-bigint = "0.4"
 color-eyre = "=0.6.2"
+derivative = { version = "2", features = [ "use_core" ] }
 
 # tmp imports for espresso's sumcheck
 espresso_subroutines = {git="https://github.com/EspressoSystems/hyperplonk", package="subroutines"}

--- a/src/commitment/kzg.rs
+++ b/src/commitment/kzg.rs
@@ -1,0 +1,267 @@
+/// This file is a wrapper over arkworks/poly-commit's KZG implementation, to adapt it to the
+/// CommitmentScheme trait.
+///
+/// The motivation to do so, is that we want to be able to use KZG / Pedersen for committing to
+/// vectors indistinctly, and the arkworks KZG10 implementation contains all the methods under the
+/// same trait, which requires the Pairing trait, where the prover does not need access to the
+/// Pairing but only to G1.
+/// For our case, we want the folding schemes prover to be agnostic to pairings, since in the
+/// non-ethereum cases we may use non-pairing-friendly curves with Pedersen commitments, so the
+/// trait & types that we use should not depend on the Pairing type for the prover. Thus, we
+/// separate the CommitmentSchemeProver from the setup and verify phases, so the prover can be
+/// defined without depending on pairings.
+use ark_ec::{pairing::Pairing, AffineRepr, CurveGroup, VariableBaseMSM};
+use ark_ff::PrimeField;
+use ark_poly::{
+    univariate::DensePolynomial, DenseUVPolynomial, EvaluationDomain, Evaluations,
+    GeneralEvaluationDomain, Polynomial,
+};
+use ark_poly_commit::kzg10::{UniversalParams, VerifierKey, KZG10};
+use ark_std::{borrow::Cow, fmt::Debug};
+use ark_std::{ops::Mul, rand::Rng};
+use core::marker::PhantomData;
+use derivative::Derivative;
+use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
+
+// use super::CommitmentScheme;
+use crate::Error;
+
+/// Powers defines the same struct as in ark_poly_commit::kzg10::Powers, but instead of depending
+/// on the Pairing trait it depends on the CurveGroup trait.
+#[derive(Debug, Clone, Default, Eq, PartialEq)]
+pub struct Powers<'a, C: CurveGroup> {
+    /// Group elements of the form `β^i G`, for different values of `i`.
+    pub powers_of_g: Cow<'a, [C::Affine]>,
+    /// Group elements of the form `β^i γG`, for different values of `i`.
+    pub powers_of_gamma_g: Cow<'a, [C::Affine]>,
+}
+
+#[derive(Derivative)]
+#[derivative(
+    // Default(bound = ""),
+    // Hash(bound = ""),
+    Clone(bound = ""),
+    Debug(bound = ""),
+    PartialEq
+)]
+pub struct KZGParams<'a, P: Pairing> {
+    universal_params: UniversalParams<P>,
+    powers: Powers<'a, P::G1>,
+}
+impl<'a, P: Pairing> KZGParams<'a, P> {
+    pub fn verifier_key(self) -> VerifierKey<P> {
+        VerifierKey {
+            g: self.universal_params.powers_of_g[0],
+            gamma_g: self.universal_params.powers_of_gamma_g[&0],
+            h: self.universal_params.h,
+            beta_h: self.universal_params.beta_h,
+            prepared_h: self.universal_params.prepared_h.clone(),
+            prepared_beta_h: self.universal_params.prepared_beta_h.clone(),
+        }
+    }
+}
+
+pub struct KZGSetup<P: Pairing> {
+    _p: PhantomData<P>,
+}
+
+impl<'a, P> CommitmentSetup<'a, P> for KZGSetup<P>
+where
+    P: Pairing,
+{
+    type Params = KZGParams<'a, P>;
+    fn setup<R: Rng>(rng: &mut R, len: usize) -> Self::Params {
+        let len = len.next_power_of_two();
+        let universal_params = KZG10::<P, DensePolynomial<P::ScalarField>>::setup(len, false, rng)
+            .expect("Setup failed");
+        let powers_of_g = universal_params.powers_of_g[..=len].to_vec();
+        let powers_of_gamma_g = (0..=len)
+            .map(|i| universal_params.powers_of_gamma_g[&i])
+            .collect();
+        let powers = Powers::<P::G1> {
+            powers_of_g: ark_std::borrow::Cow::Owned(powers_of_g),
+            // powers_of_gamma_g: ark_std::borrow::Cow::Owned(powers_of_gamma_g),
+            // powers_of_g: powers_of_g.clone(), // WIP
+            powers_of_gamma_g: ark_std::borrow::Cow::Owned(powers_of_gamma_g),
+        };
+        KZGParams {
+            universal_params,
+            powers,
+        }
+    }
+}
+
+pub struct KZGProver<'a, C: CurveGroup> {
+    _a: PhantomData<&'a ()>,
+    _c: PhantomData<C>,
+}
+impl<'a, C> CommitmentProver<'a, C> for KZGProver<'a, C>
+where
+    C: CurveGroup,
+{
+    // type Params = KZGParams<P>;
+    type Params = Powers<'a, C>;
+    // type VerifierParams = Powers<P>; // WIP
+    type Proof = C;
+    // type UniPoly_F = DensePolynomial<C1::ScalarField>;
+
+    /// commit implements the CommitmentProver commit interface, adapting the implementation from
+    /// https://github.com/arkworks-rs/poly-commit/tree/c724fa666e935bbba8db5a1421603bab542e15ab/poly-commit/src/kzg10/mod.rs#L178
+    /// with the main difference being the remove of the randomness and blinding factors.
+    fn commit(params: &Self::Params, v: &Vec<C::ScalarField>) -> Result<C, Error> {
+        let polynomial = poly_from_vec(v)?;
+        check_degree_is_too_large(polynomial.degree(), params.powers_of_g.len())?;
+
+        let (num_leading_zeros, plain_coeffs) =
+            skip_leading_zeros_and_convert_to_bigints(&polynomial);
+        let commitment = <C as VariableBaseMSM>::msm_bigint(
+            &params.powers_of_g[num_leading_zeros..],
+            &plain_coeffs,
+        );
+        Ok(commitment)
+    }
+    fn prove(
+        params: &Self::Params,
+        v: &Vec<C::ScalarField>,
+        challenge: C::ScalarField,
+    ) -> Result<Self::Proof, Error> {
+        let polynomial = poly_from_vec(v)?;
+        check_degree_is_too_large(polynomial.degree(), params.powers_of_g.len())?;
+
+        let witness_poly = compute_witness_polynomial::<C::ScalarField>(&polynomial, challenge);
+
+        let proof = open_with_witness_polynomial(params, challenge, &witness_poly)?;
+        Ok(proof)
+    }
+}
+pub fn verify_single<P: Pairing>(
+    vk: VerifierKey<P>,
+    cm: P::G1,
+    proof: P::G1,
+    challenge: P::ScalarField,
+    y: P::ScalarField,
+) -> Result<(), Error> {
+    let inner = cm - &vk.g.mul(y);
+    let lhs = P::pairing(inner, vk.h);
+
+    let inner = vk.beta_h.into_group() - &vk.h.mul(challenge);
+    let rhs = P::pairing(proof, inner);
+
+    if lhs != rhs {
+        return Err(Error::CommitmentVerificationFail);
+    }
+    Ok(())
+}
+
+/// method adapted from
+/// https://github.com/arkworks-rs/poly-commit/tree/c724fa666e935bbba8db5a1421603bab542e15ab/poly-commit/src/kzg10/mod.rs#L238
+/// Compute witness polynomial.
+///
+/// The witness polynomial w(x) the quotient of the division (p(x) - p(z)) / (x - z)
+/// Observe that this quotient does not change with z because
+/// p(z) is the remainder term. We can therefore omit p(z) when computing the quotient.
+fn compute_witness_polynomial<F: PrimeField>(
+    p: &DensePolynomial<F>,
+    point: F,
+) -> DensePolynomial<F> {
+    let divisor = DensePolynomial::<F>::from_coefficients_vec(vec![-point, F::one()]);
+    p / &divisor
+}
+/// method adapted from
+/// https://github.com/arkworks-rs/poly-commit/tree/c724fa666e935bbba8db5a1421603bab542e15ab/poly-commit/src/kzg10/mod.rs#L263
+fn open_with_witness_polynomial<'a, C: CurveGroup>(
+    powers: &Powers<C>,
+    point: C::ScalarField, // TODO rm? only used in the randomness case
+    witness_polynomial: &DensePolynomial<C::ScalarField>,
+) -> Result<C, Error> {
+    check_degree_is_too_large(witness_polynomial.degree(), powers.powers_of_g.len())?;
+    let (num_leading_zeros, witness_coeffs) =
+        skip_leading_zeros_and_convert_to_bigints(witness_polynomial);
+
+    let w = <C as VariableBaseMSM>::msm_bigint(
+        &powers.powers_of_g[num_leading_zeros..],
+        &witness_coeffs,
+    );
+
+    Ok(w)
+}
+
+fn poly_from_vec<F: PrimeField>(v: &Vec<F>) -> Result<DensePolynomial<F>, Error> {
+    let D = GeneralEvaluationDomain::<F>::new(v.len()).ok_or(Error::NewDomainFail)?;
+    Ok(Evaluations::from_vec_and_domain(v.clone(), D).interpolate()) // TODO rm clone
+}
+fn check_degree_is_too_large(
+    degree: usize,
+    num_powers: usize,
+) -> Result<(), ark_poly_commit::error::Error> {
+    let num_coefficients = degree + 1;
+    if num_coefficients > num_powers {
+        Err(ark_poly_commit::error::Error::TooManyCoefficients {
+            num_coefficients,
+            num_powers,
+        })
+    } else {
+        Ok(())
+    }
+}
+fn skip_leading_zeros_and_convert_to_bigints<F: PrimeField, P: DenseUVPolynomial<F>>(
+    p: &P,
+) -> (usize, Vec<F::BigInt>) {
+    let mut num_leading_zeros = 0;
+    while num_leading_zeros < p.coeffs().len() && p.coeffs()[num_leading_zeros].is_zero() {
+        num_leading_zeros += 1;
+    }
+    let coeffs = convert_to_bigints(&p.coeffs()[num_leading_zeros..]);
+    (num_leading_zeros, coeffs)
+}
+fn convert_to_bigints<F: PrimeField>(p: &[F]) -> Vec<F::BigInt> {
+    let coeffs = ark_std::cfg_iter!(p)
+        .map(|s| s.into_bigint())
+        .collect::<Vec<_>>();
+    coeffs
+}
+
+pub trait CommitmentSetup<'a, P: Pairing> {
+    type Params: Debug;
+
+    fn setup<R: Rng>(rng: &mut R, len: usize) -> Self::Params;
+}
+pub trait CommitmentProver<'a, C: CurveGroup> {
+    type Params: Debug;
+    type Proof: Debug;
+
+    fn commit(params: &Self::Params, v: &Vec<C::ScalarField>) -> Result<C, Error>;
+    fn prove(
+        params: &Self::Params,
+        v: &Vec<C::ScalarField>,
+        challenge: C::ScalarField,
+    ) -> Result<Self::Proof, Error>;
+}
+
+#[cfg(test)]
+mod tests {
+    use ark_bn254::{Bn254, Fr, G1Projective as G1};
+    use ark_std::test_rng;
+    use ark_std::UniformRand;
+
+    use super::*;
+
+    #[test]
+    fn test_kzg_commitment_scheme() {
+        let rng = &mut test_rng();
+
+        let n = 100;
+        let params: KZGParams<Bn254> = KZGSetup::<Bn254>::setup(rng, n);
+
+        let v: Vec<Fr> = std::iter::repeat_with(|| Fr::rand(rng)).take(n).collect();
+        let cm = KZGProver::<G1>::commit(&params.powers, &v).unwrap();
+        let challenge = Fr::rand(rng);
+
+        let poly_v = poly_from_vec(&v).unwrap();
+        let eval = poly_v.evaluate(&challenge);
+        let proof = KZGProver::<G1>::prove(&params.powers, &v, challenge).unwrap();
+
+        let vk = params.verifier_key();
+        verify_single::<Bn254>(vk, cm, proof, challenge, eval).unwrap();
+    }
+}

--- a/src/commitment/kzg.rs
+++ b/src/commitment/kzg.rs
@@ -1,5 +1,5 @@
-/// This file is a wrapper over arkworks/poly-commit's KZG implementation, to adapt it to the
-/// CommitmentScheme trait.
+/// Adaptation of the prover methods and structs from arkworks/poly-commit's KZG10 implementation
+/// into the CommitmentProver trait.
 ///
 /// The motivation to do so, is that we want to be able to use KZG / Pedersen for committing to
 /// vectors indistinctly, and the arkworks KZG10 implementation contains all the methods under the
@@ -16,9 +16,10 @@ use ark_poly::{
     univariate::DensePolynomial, DenseUVPolynomial, EvaluationDomain, Evaluations,
     GeneralEvaluationDomain, Polynomial,
 };
-use ark_poly_commit::kzg10::{UniversalParams, VerifierKey, KZG10};
+use ark_poly_commit::kzg10::{VerifierKey, KZG10};
 use ark_std::rand::Rng;
 use ark_std::{borrow::Cow, fmt::Debug};
+use ark_std::{One, Zero};
 use core::marker::PhantomData;
 use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
 
@@ -26,58 +27,40 @@ use super::CommitmentProver;
 use crate::transcript::Transcript;
 use crate::Error;
 
-/// Powers defines the same struct as in ark_poly_commit::kzg10::Powers, but instead of depending
-/// on the Pairing trait it depends on the CurveGroup trait.
+/// ProverKey defines a similar struct as in ark_poly_commit::kzg10::Powers, but instead of
+/// depending on the Pairing trait it depends on the CurveGroup trait.
 #[derive(Debug, Clone, Default, Eq, PartialEq)]
-pub struct Powers<'a, C: CurveGroup> {
+pub struct ProverKey<'a, C: CurveGroup> {
     /// Group elements of the form `β^i G`, for different values of `i`.
     pub powers_of_g: Cow<'a, [C::Affine]>,
-    /// Group elements of the form `β^i γG`, for different values of `i`.
-    pub powers_of_gamma_g: Cow<'a, [C::Affine]>,
-}
-
-#[derive(Debug, Clone, Eq, PartialEq)]
-pub struct KZGParams<'a, P: Pairing> {
-    pub universal_params: UniversalParams<P>,
-    pub powers: Powers<'a, P::G1>,
-}
-impl<'a, P: Pairing> KZGParams<'a, P> {
-    pub fn verifier_key(self) -> VerifierKey<P> {
-        VerifierKey {
-            g: self.universal_params.powers_of_g[0],
-            gamma_g: self.universal_params.powers_of_gamma_g[&0],
-            h: self.universal_params.h,
-            beta_h: self.universal_params.beta_h,
-            prepared_h: self.universal_params.prepared_h.clone(),
-            prepared_beta_h: self.universal_params.prepared_beta_h.clone(),
-        }
-    }
 }
 
 pub struct KZGSetup<P: Pairing> {
     _p: PhantomData<P>,
 }
-
 impl<'a, P> KZGSetup<P>
 where
     P: Pairing,
 {
-    pub fn setup<R: Rng>(rng: &mut R, len: usize) -> KZGParams<'a, P> {
+    /// setup returns the tuple (ProverKey, VerifierKey). For real world deployments the setup must
+    /// be computed in the most trustless way possible, usually through a MPC ceremony.
+    pub fn setup<R: Rng>(rng: &mut R, len: usize) -> (ProverKey<'a, P::G1>, VerifierKey<P>) {
         let len = len.next_power_of_two();
         let universal_params = KZG10::<P, DensePolynomial<P::ScalarField>>::setup(len, false, rng)
             .expect("Setup failed");
         let powers_of_g = universal_params.powers_of_g[..=len].to_vec();
-        let powers_of_gamma_g = (0..=len)
-            .map(|i| universal_params.powers_of_gamma_g[&i])
-            .collect();
-        let powers = Powers::<P::G1> {
+        let powers = ProverKey::<P::G1> {
             powers_of_g: ark_std::borrow::Cow::Owned(powers_of_g),
-            powers_of_gamma_g: ark_std::borrow::Cow::Owned(powers_of_gamma_g),
         };
-        KZGParams {
-            universal_params,
-            powers,
-        }
+        let vk = VerifierKey {
+            g: universal_params.powers_of_g[0],
+            gamma_g: universal_params.powers_of_gamma_g[&0],
+            h: universal_params.h,
+            beta_h: universal_params.beta_h,
+            prepared_h: universal_params.prepared_h.clone(),
+            prepared_beta_h: universal_params.prepared_beta_h.clone(),
+        };
+        (powers, vk)
     }
 }
 
@@ -86,12 +69,13 @@ pub struct KZGProver<'a, C: CurveGroup> {
     _a: PhantomData<&'a ()>,
     _c: PhantomData<C>,
 }
-impl<'a, C> CommitmentProver<'a, C> for KZGProver<'a, C>
+impl<'a, C> CommitmentProver<C> for KZGProver<'a, C>
 where
     C: CurveGroup,
 {
-    type Params = Powers<'a, C>;
-    type Proof = (C::ScalarField, C); // (evaluation, proof)
+    type Params = ProverKey<'a, C>;
+    /// Proof is a tuple containing (evaluation, proof)
+    type Proof = (C::ScalarField, C);
 
     /// commit implements the CommitmentProver commit interface, adapting the implementation from
     /// https://github.com/arkworks-rs/poly-commit/tree/c724fa666e935bbba8db5a1421603bab542e15ab/poly-commit/src/kzg10/mod.rs#L178
@@ -102,7 +86,11 @@ where
         v: &[C::ScalarField],
         _blind: &C::ScalarField,
     ) -> Result<C, Error> {
-        let polynomial = poly_from_vec(&v.to_vec())?;
+        if !_blind.is_zero() {
+            return Err(Error::NotSupportedYet("blinding factors".to_string()));
+        }
+
+        let polynomial = poly_from_vec(v.to_vec())?;
         check_degree_is_too_large(polynomial.degree(), params.powers_of_g.len())?;
 
         let (num_leading_zeros, plain_coeffs) =
@@ -125,56 +113,44 @@ where
         v: &[C::ScalarField],
         _blind: &C::ScalarField,
     ) -> Result<Self::Proof, Error> {
-        let polynomial = poly_from_vec(&v.to_vec())?;
+        if !_blind.is_zero() {
+            return Err(Error::NotSupportedYet("blinding factors".to_string()));
+        }
+
+        let polynomial = poly_from_vec(v.to_vec())?;
         check_degree_is_too_large(polynomial.degree(), params.powers_of_g.len())?;
 
         transcript.absorb_point(cm)?;
         let challenge = transcript.get_challenge();
 
-        let witness_poly = compute_witness_polynomial::<C::ScalarField>(&polynomial, challenge);
+        // Compute q(x) = (p(x) - p(z)) / (x-z). Observe that this quotient does not change with z
+        // because p(z) is the remainder term. We can therefore omit p(z) when computing the
+        // quotient.
+        let divisor = DensePolynomial::<C::ScalarField>::from_coefficients_vec(vec![
+            -challenge,
+            C::ScalarField::one(),
+        ]);
+        let witness_poly: DensePolynomial<C::ScalarField> = &polynomial / &divisor;
 
-        let proof = open_with_witness_polynomial(params, challenge, &witness_poly)?;
+        check_degree_is_too_large(witness_poly.degree(), params.powers_of_g.len())?;
+        let (num_leading_zeros, witness_coeffs) =
+            skip_leading_zeros_and_convert_to_bigints(&witness_poly);
+        let proof = <C as VariableBaseMSM>::msm_bigint(
+            &params.powers_of_g[num_leading_zeros..],
+            &witness_coeffs,
+        );
+
         Ok((polynomial.evaluate(&challenge), proof))
     }
 }
 
-/// method adapted from
-/// https://github.com/arkworks-rs/poly-commit/tree/c724fa666e935bbba8db5a1421603bab542e15ab/poly-commit/src/kzg10/mod.rs#L238
-/// Compute witness polynomial.
-///
-/// The witness polynomial w(x) the quotient of the division (p(x) - p(z)) / (x - z)
-/// Observe that this quotient does not change with z because
-/// p(z) is the remainder term. We can therefore omit p(z) when computing the quotient.
-fn compute_witness_polynomial<F: PrimeField>(
-    p: &DensePolynomial<F>,
-    point: F,
-) -> DensePolynomial<F> {
-    let divisor = DensePolynomial::<F>::from_coefficients_vec(vec![-point, F::one()]);
-    p / &divisor
-}
-/// method adapted from
-/// https://github.com/arkworks-rs/poly-commit/tree/c724fa666e935bbba8db5a1421603bab542e15ab/poly-commit/src/kzg10/mod.rs#L263
-fn open_with_witness_polynomial<C: CurveGroup>(
-    powers: &Powers<C>,
-    _point: C::ScalarField, // TODO rm? only used in the randomness case
-    witness_polynomial: &DensePolynomial<C::ScalarField>,
-) -> Result<C, Error> {
-    check_degree_is_too_large(witness_polynomial.degree(), powers.powers_of_g.len())?;
-    let (num_leading_zeros, witness_coeffs) =
-        skip_leading_zeros_and_convert_to_bigints(witness_polynomial);
-
-    let w = <C as VariableBaseMSM>::msm_bigint(
-        &powers.powers_of_g[num_leading_zeros..],
-        &witness_coeffs,
-    );
-
-    Ok(w)
-}
-
-fn poly_from_vec<F: PrimeField>(v: &Vec<F>) -> Result<DensePolynomial<F>, Error> {
+/// returns the unique polynomial of degree=v.len().next_power_of_two(), which passes through all
+/// the given elements of v
+fn poly_from_vec<F: PrimeField>(v: Vec<F>) -> Result<DensePolynomial<F>, Error> {
     let D = GeneralEvaluationDomain::<F>::new(v.len()).ok_or(Error::NewDomainFail)?;
-    Ok(Evaluations::from_vec_and_domain(v.clone(), D).interpolate()) // TODO rm clone
+    Ok(Evaluations::from_vec_and_domain(v, D).interpolate())
 }
+
 fn check_degree_is_too_large(
     degree: usize,
     num_powers: usize,
@@ -189,6 +165,7 @@ fn check_degree_is_too_large(
         Ok(())
     }
 }
+
 fn skip_leading_zeros_and_convert_to_bigints<F: PrimeField, P: DenseUVPolynomial<F>>(
     p: &P,
 ) -> (usize, Vec<F::BigInt>) {
@@ -199,6 +176,7 @@ fn skip_leading_zeros_and_convert_to_bigints<F: PrimeField, P: DenseUVPolynomial
     let coeffs = convert_to_bigints(&p.coeffs()[num_leading_zeros..]);
     (num_leading_zeros, coeffs)
 }
+
 fn convert_to_bigints<F: PrimeField>(p: &[F]) -> Vec<F::BigInt> {
     ark_std::cfg_iter!(p)
         .map(|s| s.into_bigint())
@@ -209,7 +187,6 @@ fn convert_to_bigints<F: PrimeField>(p: &[F]) -> Vec<F::BigInt> {
 mod tests {
     use ark_bn254::{Bn254, Fr, G1Projective as G1};
     use ark_poly_commit::kzg10::{Commitment as KZG10Commitment, Proof as KZG10Proof, KZG10};
-    use ark_std::Zero;
     use ark_std::{test_rng, UniformRand};
 
     use super::*;
@@ -222,22 +199,19 @@ mod tests {
         let transcript_p = &mut PoseidonTranscript::<G1>::new(&poseidon_config);
         let transcript_v = &mut PoseidonTranscript::<G1>::new(&poseidon_config);
 
-        let n = 3;
-        let params: KZGParams<Bn254> = KZGSetup::<Bn254>::setup(rng, n);
+        let n = 10;
+        let (pk, vk): (ProverKey<G1>, VerifierKey<Bn254>) = KZGSetup::<Bn254>::setup(rng, n);
 
         let v: Vec<Fr> = std::iter::repeat_with(|| Fr::rand(rng)).take(n).collect();
-        let cm = KZGProver::<G1>::commit(&params.powers, &v, &Fr::zero()).unwrap();
+        let cm = KZGProver::<G1>::commit(&pk, &v, &Fr::zero()).unwrap();
 
         let (eval, proof) =
-            KZGProver::<G1>::prove(&params.powers, transcript_p, &cm, &v, &Fr::zero()).unwrap();
+            KZGProver::<G1>::prove(&pk, transcript_p, &cm, &v, &Fr::zero()).unwrap();
 
         // verify the proof:
-        let vk = params.verifier_key();
-
         // get evaluation challenge
         transcript_v.absorb_point(&cm).unwrap();
         let challenge = transcript_v.get_challenge();
-
         // verify the KZG proof using arkworks method
         assert!(KZG10::<Bn254, DensePolynomial<Fr>>::check(
             &vk,

--- a/src/commitment/mod.rs
+++ b/src/commitment/mod.rs
@@ -1,0 +1,19 @@
+use ark_ec::CurveGroup;
+use ark_std::fmt::Debug;
+
+use crate::Error;
+
+pub mod kzg;
+pub mod pedersen;
+
+/// CommitmentScheme defines a common trait for both polynomial commitment schemes and vector
+/// commitment schemes, such as KZG and Pedersen commitments.
+pub trait CommitmentScheme<C1: CurveGroup, C2: CurveGroup> {
+    type Params: Debug;
+    type Proof: Debug;
+
+    fn setup() -> Self::Params;
+    fn commit(params: Self::Params, v: Vec<C1::ScalarField>) -> C1;
+    fn prove(params: Self::Params, v: Vec<C1::ScalarField>) -> Self::Proof;
+    fn verify(params: Self::Params, cm: C1, proof: Self::Proof) -> Result<(), Error>;
+}

--- a/src/commitment/mod.rs
+++ b/src/commitment/mod.rs
@@ -1,19 +1,27 @@
 use ark_ec::CurveGroup;
 use ark_std::fmt::Debug;
 
+use crate::transcript::Transcript;
 use crate::Error;
 
 pub mod kzg;
 pub mod pedersen;
 
-/// CommitmentScheme defines a common trait for both polynomial commitment schemes and vector
-/// commitment schemes, such as KZG and Pedersen commitments.
-pub trait CommitmentScheme<C1: CurveGroup, C2: CurveGroup> {
+/// CommitmentProver defines the vector commitment scheme prover trait.
+pub trait CommitmentProver<'a, C: CurveGroup> {
     type Params: Debug;
     type Proof: Debug;
 
-    fn setup() -> Self::Params;
-    fn commit(params: Self::Params, v: Vec<C1::ScalarField>) -> C1;
-    fn prove(params: Self::Params, v: Vec<C1::ScalarField>) -> Self::Proof;
-    fn verify(params: Self::Params, cm: C1, proof: Self::Proof) -> Result<(), Error>;
+    fn commit(
+        params: &Self::Params,
+        v: &[C::ScalarField],
+        blind: &C::ScalarField,
+    ) -> Result<C, Error>;
+    fn prove(
+        params: &Self::Params,
+        transcript: &mut impl Transcript<C>,
+        cm: &C,
+        v: &[C::ScalarField],
+        blind: &C::ScalarField,
+    ) -> Result<Self::Proof, Error>;
 }

--- a/src/commitment/mod.rs
+++ b/src/commitment/mod.rs
@@ -25,3 +25,106 @@ pub trait CommitmentProver<'a, C: CurveGroup> {
         blind: &C::ScalarField,
     ) -> Result<Self::Proof, Error>;
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ark_bn254::{Bn254, Fr, G1Projective as G1};
+    use ark_crypto_primitives::sponge::{poseidon::PoseidonConfig, Absorb};
+    use ark_poly::univariate::DensePolynomial;
+    use ark_poly_commit::kzg10::{Commitment as KZG10Commitment, Proof as KZG10Proof, KZG10};
+    use ark_std::Zero;
+    use ark_std::{test_rng, UniformRand};
+
+    use super::kzg::{KZGParams, KZGProver, KZGSetup};
+    use super::pedersen::Pedersen;
+    use crate::transcript::{
+        poseidon::{tests::poseidon_test_config, PoseidonTranscript},
+        Transcript,
+    };
+
+    // Computes the commitment of the two vectors using the given CommitmentProver, then computes
+    // their random linear combination, and returns it together with the proof of it.
+    fn commit_rlc_and_proof<'a, C: CurveGroup, CP: CommitmentProver<'a, C>>(
+        poseidon_config: &PoseidonConfig<C::ScalarField>,
+        params: &CP::Params,
+        r: C::ScalarField,
+        v_1: Vec<C::ScalarField>,
+        v_2: Vec<C::ScalarField>,
+    ) -> Result<(C, CP::Proof), Error>
+    where
+        <C as ark_ec::Group>::ScalarField: Absorb,
+    {
+        let cm_1 = CP::commit(params, &v_1, &C::ScalarField::zero())?;
+        let cm_2 = CP::commit(params, &v_2, &C::ScalarField::zero())?;
+
+        // random linear combination of the commitment and the witness (vector v)
+        let cm_3 = cm_1 + cm_2.mul(r);
+        let v_3: Vec<C::ScalarField> = v_1.iter().zip(&v_2).map(|(a, b)| *a + (r * b)).collect();
+
+        let transcript = &mut PoseidonTranscript::<C>::new(poseidon_config);
+        let proof = CP::prove(params, transcript, &cm_3, &v_3, &C::ScalarField::zero()).unwrap();
+
+        Ok((cm_3, proof))
+    }
+
+    #[test]
+    fn test_homomorphic_property_using_CommitmentProver_trait() {
+        let rng = &mut test_rng();
+        let poseidon_config = poseidon_test_config::<Fr>();
+        let n: usize = 100;
+
+        // set random vector for the test
+        let v_1: Vec<Fr> = std::iter::repeat_with(|| Fr::rand(rng)).take(n).collect();
+        let v_2: Vec<Fr> = std::iter::repeat_with(|| Fr::rand(rng)).take(n).collect();
+        // set a random challenge for the random linear combination
+        let r = Fr::rand(rng);
+
+        // setup params for Pedersen & KZG
+        let pedersen_params = Pedersen::<G1>::new_params(rng, n);
+        let kzg_params: KZGParams<Bn254> = KZGSetup::<Bn254>::setup(rng, n);
+
+        // Pedersen commit the two vectors and return their random linear combination and proof
+        let (pedersen_cm, pedersen_proof) = commit_rlc_and_proof::<G1, Pedersen<G1>>(
+            &poseidon_config,
+            &pedersen_params,
+            r,
+            v_1.clone(),
+            v_2.clone(),
+        )
+        .unwrap();
+
+        // KZG commit the two vectors and return their random linear combination and proof
+        let (kzg_cm, kzg_proof) = commit_rlc_and_proof::<G1, KZGProver<G1>>(
+            &poseidon_config,
+            &kzg_params.powers,
+            r,
+            v_1,
+            v_2,
+        )
+        .unwrap();
+
+        // verify Pedersen
+        let transcript_v = &mut PoseidonTranscript::<G1>::new(&poseidon_config);
+        Pedersen::<G1>::verify(&pedersen_params, transcript_v, pedersen_cm, pedersen_proof)
+            .unwrap();
+
+        // verify KZG
+        let transcript_v = &mut PoseidonTranscript::<G1>::new(&poseidon_config);
+        transcript_v.absorb_point(&kzg_cm).unwrap();
+        let challenge = transcript_v.get_challenge();
+        let vk = kzg_params.verifier_key();
+        // verify the KZG proof using arkworks method
+        assert!(KZG10::<Bn254, DensePolynomial<Fr>>::check(
+            &vk,
+            &KZG10Commitment(kzg_cm.into_affine()),
+            challenge,
+            kzg_proof.0, // eval
+            &KZG10Proof::<Bn254> {
+                w: kzg_proof.1.into_affine(), // proof
+                random_v: None,
+            },
+        )
+        .unwrap());
+    }
+}

--- a/src/commitment/pedersen.rs
+++ b/src/commitment/pedersen.rs
@@ -53,6 +53,14 @@ impl<C: CurveGroup> Pedersen<C> {
         Ok(params.h.mul(r) + C::msm_unchecked(&params.generators[..v.len()], v))
     }
 
+    // pub fn prove(
+    //     params: &Params<C>,
+    //     transcript: &mut impl Transcript<C>, // TODO rm
+    //     cm: &C, // TODO rm
+    //     v: &Vec<C::ScalarField>,
+    //     // TODO potser afegir challenge? o pedersen no n'usa?
+    //     r: &C::ScalarField, // TODO es el blinding factor? comprovar
+    // ) -> Result<Proof<C>, Error> {
     pub fn prove(
         params: &Params<C>,
         transcript: &mut impl Transcript<C>,
@@ -108,7 +116,7 @@ impl<C: CurveGroup> Pedersen<C> {
         let rhs = params.h.mul(proof.r_u)
             + C::msm_unchecked(&params.generators[..proof.u.len()], &proof.u);
         if lhs != rhs {
-            return Err(Error::PedersenVerificationFail);
+            return Err(Error::CommitmentVerificationFail);
         }
         Ok(())
     }

--- a/src/commitment/pedersen.rs
+++ b/src/commitment/pedersen.rs
@@ -170,7 +170,7 @@ mod tests {
     fn test_pedersen_vector() {
         let mut rng = ark_std::test_rng();
 
-        const n: usize = 10;
+        let n: usize = 10;
         // setup params
         let params = Pedersen::<Projective>::new_params(&mut rng, n);
         let poseidon_config = poseidon_test_config::<Fr>();
@@ -193,7 +193,7 @@ mod tests {
     fn test_pedersen_circuit() {
         let mut rng = ark_std::test_rng();
 
-        const n: usize = 10;
+        let n: usize = 10;
         // setup params
         let params = Pedersen::<Projective>::new_params(&mut rng, n);
 

--- a/src/commitment/pedersen.rs
+++ b/src/commitment/pedersen.rs
@@ -41,7 +41,8 @@ impl<C: CurveGroup> Pedersen<C> {
     }
 }
 
-impl<C: CurveGroup> CommitmentProver<'_, C> for Pedersen<C> {
+// implement the CommitmentProver trait for Pedersen
+impl<C: CurveGroup> CommitmentProver<C> for Pedersen<C> {
     type Params = Params<C>;
     type Proof = Proof<C>;
     fn commit(

--- a/src/folding/hypernova/cccs.rs
+++ b/src/folding/hypernova/cccs.rs
@@ -9,7 +9,10 @@ use ark_std::{rand::Rng, UniformRand};
 
 use super::utils::compute_sum_Mz;
 use crate::ccs::CCS;
-use crate::commitment::pedersen::{Params as PedersenParams, Pedersen};
+use crate::commitment::{
+    pedersen::{Params as PedersenParams, Pedersen},
+    CommitmentProver,
+};
 use crate::utils::hypercube::BooleanHypercube;
 use crate::utils::mle::matrix_to_mle;
 use crate::utils::mle::vec_to_mle;

--- a/src/folding/hypernova/cccs.rs
+++ b/src/folding/hypernova/cccs.rs
@@ -9,7 +9,7 @@ use ark_std::{rand::Rng, UniformRand};
 
 use super::utils::compute_sum_Mz;
 use crate::ccs::CCS;
-use crate::pedersen::{Params as PedersenParams, Pedersen};
+use crate::commitment::pedersen::{Params as PedersenParams, Pedersen};
 use crate::utils::hypercube::BooleanHypercube;
 use crate::utils::mle::matrix_to_mle;
 use crate::utils::mle::vec_to_mle;

--- a/src/folding/hypernova/circuit.rs
+++ b/src/folding/hypernova/circuit.rs
@@ -157,11 +157,11 @@ mod tests {
             tests::{get_test_ccs, get_test_z},
             CCS,
         },
+        commitment::pedersen::Pedersen,
         folding::hypernova::utils::{
             compute_c_from_sigmas_and_thetas, compute_sigmas_and_thetas, sum_ci_mul_prod_thetaj,
             sum_muls_gamma_pows_eq_sigma,
         },
-        pedersen::Pedersen,
         utils::virtual_polynomial::eq_eval,
     };
     use ark_pallas::{Fr, Projective};

--- a/src/folding/hypernova/lcccs.rs
+++ b/src/folding/hypernova/lcccs.rs
@@ -8,7 +8,7 @@ use ark_std::{rand::Rng, UniformRand};
 use super::cccs::Witness;
 use super::utils::{compute_all_sum_Mz_evals, compute_sum_Mz};
 use crate::ccs::CCS;
-use crate::pedersen::{Params as PedersenParams, Pedersen};
+use crate::commitment::pedersen::{Params as PedersenParams, Pedersen};
 use crate::utils::mle::{matrix_to_mle, vec_to_mle};
 use crate::utils::virtual_polynomial::VirtualPolynomial;
 use crate::Error;

--- a/src/folding/hypernova/lcccs.rs
+++ b/src/folding/hypernova/lcccs.rs
@@ -8,7 +8,10 @@ use ark_std::{rand::Rng, UniformRand};
 use super::cccs::Witness;
 use super::utils::{compute_all_sum_Mz_evals, compute_sum_Mz};
 use crate::ccs::CCS;
-use crate::commitment::pedersen::{Params as PedersenParams, Pedersen};
+use crate::commitment::{
+    pedersen::{Params as PedersenParams, Pedersen},
+    CommitmentProver,
+};
 use crate::utils::mle::{matrix_to_mle, vec_to_mle};
 use crate::utils::virtual_polynomial::VirtualPolynomial;
 use crate::Error;

--- a/src/folding/hypernova/nimfs.rs
+++ b/src/folding/hypernova/nimfs.rs
@@ -213,7 +213,7 @@ where
         //////////////////////////////////////////////////////////////////////
         let mut g_over_bhc = C::ScalarField::zero();
         for x in BooleanHypercube::new(ccs.s) {
-            g_over_bhc += g.evaluate(&x).unwrap();
+            g_over_bhc += g.evaluate(&x)?;
         }
 
         // note: this is the sum of g(x) over the whole boolean hypercube
@@ -378,7 +378,7 @@ pub mod tests {
     use ark_std::test_rng;
     use ark_std::UniformRand;
 
-    use crate::pedersen::Pedersen;
+    use crate::commitment::pedersen::Pedersen;
     use ark_pallas::{Fr, Projective};
 
     #[test]

--- a/src/folding/hypernova/utils.rs
+++ b/src/folding/hypernova/utils.rs
@@ -199,7 +199,7 @@ pub mod tests {
     use ark_std::Zero;
 
     use crate::ccs::tests::{get_test_ccs, get_test_z};
-    use crate::pedersen::Pedersen;
+    use crate::commitment::pedersen::Pedersen;
     use crate::utils::multilinear_polynomial::tests::fix_last_variables;
     use crate::utils::virtual_polynomial::eq_eval;
 

--- a/src/folding/nova/circuits.rs
+++ b/src/folding/nova/circuits.rs
@@ -470,12 +470,12 @@ pub mod tests {
     use tracing_subscriber::layer::SubscriberExt;
 
     use crate::ccs::r1cs::{extract_r1cs, extract_w_x};
+    use crate::commitment::pedersen::Pedersen;
     use crate::folding::nova::nifs::tests::prepare_simple_fold_inputs;
     use crate::folding::nova::{
         ivc::get_committed_instance_coordinates, nifs::NIFS, traits::NovaR1CS, Witness,
     };
     use crate::frontend::tests::CubicFCircuit;
-    use crate::pedersen::Pedersen;
     use crate::transcript::poseidon::tests::poseidon_test_config;
 
     #[test]

--- a/src/folding/nova/decider.rs
+++ b/src/folding/nova/decider.rs
@@ -18,13 +18,13 @@ use ark_std::{One, Zero};
 use core::{borrow::Borrow, marker::PhantomData};
 
 use crate::ccs::r1cs::R1CS;
+use crate::commitment::pedersen::Params as PedersenParams;
 use crate::folding::nova::{
     circuits::{CommittedInstanceVar, CF1, CF2},
     ivc::IVC,
     CommittedInstance, Witness,
 };
 use crate::frontend::FCircuit;
-use crate::pedersen::Params as PedersenParams;
 use crate::utils::gadgets::{
     hadamard, mat_vec_mul_sparse, vec_add, vec_scalar_mul, SparseMatrixVar,
 };
@@ -355,8 +355,8 @@ where
         {
             // imports here instead of at the top of the file, so we avoid having multiple
             // `#[cfg(not(test))]
+            use crate::commitment::pedersen::PedersenGadget;
             use crate::folding::nova::cyclefold::{CycleFoldCommittedInstanceVar, CF_IO_LEN};
-            use crate::pedersen::PedersenGadget;
             use ark_r1cs_std::ToBitsGadget;
 
             let cf_r1cs = R1CSVar::<

--- a/src/folding/nova/ivc.rs
+++ b/src/folding/nova/ivc.rs
@@ -301,7 +301,6 @@ where
         self.z_i = z_i1.clone();
         self.w_i = Witness::<C1>::new(w_i1, self.r1cs.A.n_rows);
         self.u_i = self.w_i.commit(&self.pedersen_params, vec![u_i1_x])?;
-        // TODO WIP // self.u_i = self.w_i.commit_kzg(&self.pedersen_params, vec![u_i1_x])?;
         self.W_i = W_i1.clone();
         self.U_i = U_i1.clone();
 

--- a/src/folding/nova/ivc.rs
+++ b/src/folding/nova/ivc.rs
@@ -14,8 +14,8 @@ use super::{
 use super::{nifs::NIFS, traits::NovaR1CS, CommittedInstance, Witness};
 use crate::ccs::r1cs::R1CS;
 use crate::ccs::r1cs::{extract_r1cs, extract_w_x};
+use crate::commitment::pedersen::{Params as PedersenParams, Pedersen};
 use crate::frontend::FCircuit;
-use crate::pedersen::{Params as PedersenParams, Pedersen};
 use crate::Error;
 
 #[cfg(test)]
@@ -301,6 +301,7 @@ where
         self.z_i = z_i1.clone();
         self.w_i = Witness::<C1>::new(w_i1, self.r1cs.A.n_rows);
         self.u_i = self.w_i.commit(&self.pedersen_params, vec![u_i1_x])?;
+        // TODO WIP // self.u_i = self.w_i.commit_kzg(&self.pedersen_params, vec![u_i1_x])?;
         self.W_i = W_i1.clone();
         self.U_i = U_i1.clone();
 

--- a/src/folding/nova/mod.rs
+++ b/src/folding/nova/mod.rs
@@ -92,11 +92,12 @@ where
     <C as Group>::ScalarField: Absorb,
 {
     pub fn new(w: Vec<C::ScalarField>, e_len: usize) -> Self {
+        // note: at the current version, we set the blinding factors to 0 always.
         Self {
             E: vec![C::ScalarField::zero(); e_len],
-            rE: C::ScalarField::zero(), // because we use C::zero() as cmE
+            rE: C::ScalarField::zero(),
             W: w,
-            rW: C::ScalarField::one(),
+            rW: C::ScalarField::zero(),
         }
     }
     pub fn commit(

--- a/src/folding/nova/mod.rs
+++ b/src/folding/nova/mod.rs
@@ -7,8 +7,8 @@ use ark_ec::{CurveGroup, Group};
 use ark_std::fmt::Debug;
 use ark_std::{One, Zero};
 
+use crate::commitment::pedersen::{Params as PedersenParams, Pedersen};
 use crate::folding::circuits::nonnative::point_to_nonnative_limbs;
-use crate::pedersen::{Params as PedersenParams, Pedersen};
 use crate::utils::vec::is_zero_vec;
 use crate::Error;
 

--- a/src/folding/nova/mod.rs
+++ b/src/folding/nova/mod.rs
@@ -92,7 +92,8 @@ where
     <C as Group>::ScalarField: Absorb,
 {
     pub fn new(w: Vec<C::ScalarField>, e_len: usize) -> Self {
-        // note: at the current version, we set the blinding factors to 0 always.
+        // note: at the current version, we don't use the blinding factors and we set them to 0
+        // always.
         Self {
             E: vec![C::ScalarField::zero(); e_len],
             rE: C::ScalarField::zero(),

--- a/src/folding/nova/mod.rs
+++ b/src/folding/nova/mod.rs
@@ -7,7 +7,10 @@ use ark_ec::{CurveGroup, Group};
 use ark_std::fmt::Debug;
 use ark_std::{One, Zero};
 
-use crate::commitment::pedersen::{Params as PedersenParams, Pedersen};
+use crate::commitment::{
+    pedersen::{Params as PedersenParams, Pedersen},
+    CommitmentProver,
+};
 use crate::folding::circuits::nonnative::point_to_nonnative_limbs;
 use crate::utils::vec::is_zero_vec;
 use crate::Error;

--- a/src/folding/nova/nifs.rs
+++ b/src/folding/nova/nifs.rs
@@ -5,7 +5,7 @@ use std::marker::PhantomData;
 
 use super::{CommittedInstance, Witness};
 use crate::ccs::r1cs::R1CS;
-use crate::pedersen::{Params as PedersenParams, Pedersen, Proof as PedersenProof};
+use crate::commitment::pedersen::{Params as PedersenParams, Pedersen, Proof as PedersenProof};
 use crate::transcript::Transcript;
 use crate::utils::vec::*;
 use crate::Error;

--- a/src/folding/nova/nifs.rs
+++ b/src/folding/nova/nifs.rs
@@ -5,7 +5,10 @@ use std::marker::PhantomData;
 
 use super::{CommittedInstance, Witness};
 use crate::ccs::r1cs::R1CS;
-use crate::commitment::pedersen::{Params as PedersenParams, Pedersen, Proof as PedersenProof};
+use crate::commitment::{
+    pedersen::{Params as PedersenParams, Pedersen, Proof as PedersenProof},
+    CommitmentProver,
+};
 use crate::transcript::Transcript;
 use crate::utils::vec::*;
 use crate::Error;

--- a/src/folding/protogalaxy/folding.rs
+++ b/src/folding/protogalaxy/folding.rs
@@ -369,7 +369,7 @@ mod tests {
     use ark_std::UniformRand;
 
     use crate::ccs::r1cs::tests::{get_test_r1cs, get_test_z};
-    use crate::pedersen::Pedersen;
+    use crate::commitment::pedersen::Pedersen;
     use crate::transcript::poseidon::{tests::poseidon_test_config, PoseidonTranscript};
 
     pub(crate) fn check_instance<C: CurveGroup>(

--- a/src/folding/protogalaxy/folding.rs
+++ b/src/folding/protogalaxy/folding.rs
@@ -369,7 +369,7 @@ mod tests {
     use ark_std::UniformRand;
 
     use crate::ccs::r1cs::tests::{get_test_r1cs, get_test_z};
-    use crate::commitment::pedersen::Pedersen;
+    use crate::commitment::{pedersen::Pedersen, CommitmentProver};
     use crate::transcript::poseidon::{tests::poseidon_test_config, PoseidonTranscript};
 
     pub(crate) fn check_instance<C: CurveGroup>(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,10 +9,10 @@ use thiserror::Error;
 pub mod transcript;
 use transcript::Transcript;
 pub mod ccs;
+pub mod commitment;
 pub mod constants;
 pub mod folding;
 pub mod frontend;
-pub mod pedersen;
 pub mod utils;
 
 #[derive(Debug, Error)]
@@ -21,6 +21,10 @@ pub enum Error {
     SynthesisError(#[from] ark_relations::r1cs::SynthesisError),
     #[error("ark_serialize::SerializationError")]
     SerializationError(#[from] ark_serialize::SerializationError),
+    #[error("ark_poly_commit::Error")]
+    PolyCommitError(#[from] ark_poly_commit::Error),
+    #[error("crate::utils::espresso::virtual_polynomial::ArithErrors")]
+    ArithError(#[from] utils::espresso::virtual_polynomial::ArithErrors),
     #[error("{0}")]
     Other(String),
 
@@ -36,8 +40,8 @@ pub enum Error {
     Empty,
     #[error("Pedersen parameters length is not suficient (generators.len={0} < vector.len={1} unsatisfied)")]
     PedersenParamsLen(usize, usize),
-    #[error("Pedersen verification failed")]
-    PedersenVerificationFail,
+    #[error("Commitment verification failed")]
+    CommitmentVerificationFail,
     #[error("IVC verification failed")]
     IVCVerificationFail,
     #[error("R1CS instance is expected to not be relaxed")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,6 +56,8 @@ pub enum Error {
     OutOfBounds,
     #[error("Could not construct the Evaluation Domain")]
     NewDomainFail,
+    #[error("Feature '{0}' not supported yet")]
+    NotSupportedYet(String),
 
     #[error(transparent)]
     ProtoGalaxy(folding::protogalaxy::ProtoGalaxyError),


### PR DESCRIPTION
- Add `CommitmentProver` trait as a interface for the CommittedInstances that will use this trait to commit to the witness (and if needed to the error terms)
- Addapt `pedersen.rs` to the new `CommitmentProver` trait (and move it under the new `src/commitment/` dir
- Add `KZGProver` implementing the `CommitmentProver` trait, by adapting arkworks/poly-commit::kzg10 commit & open implementation

At line [kzg.rs#4](https://github.com/privacy-scaling-explorations/folding-schemes/blob/586d3d2d1e9a1e54f2bdbcce61bf24b3f56aeaf5/src/commitment/kzg.rs#L4) there is the rationale on why doing the `CommitmentProver` trait:
> The motivation to do so, is that we want to be able to use KZG / Pedersen for committing to
> vectors indistinctly, and the arkworks KZG10 implementation contains all the methods under the
> same trait, which requires the Pairing trait, where the prover does not need access to the
> Pairing but only to G1.
> For our case, we want the folding schemes prover to be agnostic to pairings, since in the
> non-ethereum cases we may use non-pairing-friendly curves with Pedersen commitments, so the
> trait & types that we use should not depend on the Pairing type for the prover. Therefore, we
> separate the CommitmentSchemeProver from the setup and verify phases, so the prover can be
> defined without depending on pairings.
