### PR TITLE
Add IPA commitment scheme and the respective circuit verifier gadget

### DIFF
--- a/folding-schemes-solidity/src/verifiers/mod.rs
+++ b/folding-schemes-solidity/src/verifiers/mod.rs
@@ -243,7 +243,7 @@ mod tests {
         let v: Vec<Fr> = std::iter::repeat_with(|| Fr::rand(rng)).take(n).collect();
         let cm = KZGProver::<G1>::commit(&pk, &v, &Fr::zero()).unwrap();
         let (eval, proof) =
-            KZGProver::<G1>::prove(&pk, transcript_p, &cm, &v, &Fr::zero()).unwrap();
+            KZGProver::<G1>::prove(&pk, transcript_p, &cm, &v, &Fr::zero(), None).unwrap();
         let template = KZG10Verifier::from(
             &vk,
             &pk.powers_of_g[..5],

--- a/folding-schemes/src/commitment/ipa.rs
+++ b/folding-schemes/src/commitment/ipa.rs
@@ -1,0 +1,309 @@
+use ark_ec::{AffineRepr, CurveGroup};
+use ark_ff::{Field, PrimeField};
+use ark_r1cs_std::{
+    boolean::Boolean, fields::fp::FpVar, groups::GroupOpsBounds, prelude::CurveVar,
+};
+use ark_relations::r1cs::SynthesisError;
+use ark_std::{UniformRand, Zero};
+use core::marker::PhantomData;
+
+use super::pedersen::Params as PedersenParams;
+use crate::utils::vec::{vec_add, vec_scalar_mul};
+use crate::Error;
+
+pub struct IPA<C: CurveGroup> {
+    _c: PhantomData<C>,
+    d: u64,
+    H: C,
+    Gs: Vec<C>,
+}
+
+pub struct Proof<C: CurveGroup> {
+    a: C::ScalarField,
+    l: Vec<C::ScalarField>,
+    r: Vec<C::ScalarField>,
+    L: Vec<C>,
+    R: Vec<C>,
+}
+
+impl<C: CurveGroup> IPA<C> {
+    // pub fn new(params: &PedersenParams<C>, d: u32) -> Self {
+    //     let mut rng = ark_std::rand::thread_rng();
+    //
+    //     let mut gs: Vec<C> = Vec::new();
+    //     for _ in 0..d {
+    //         gs.push(C::rand(&mut rng));
+    //     }
+    //
+    //     IPA {
+    //         d,
+    //         H: C::rand(&mut rng),
+    //         Gs: gs,
+    //     }
+    // }
+
+    pub fn commit(
+        params: &PedersenParams<C>,
+        a: &[C::ScalarField],
+        r: &C::ScalarField, // blinding factor
+    ) -> Result<C, Error> {
+        if params.generators.len() < a.len() {
+            return Err(Error::PedersenParamsLen(params.generators.len(), a.len()));
+        }
+        // h⋅r + <g, v>
+        // use msm_unchecked because we already ensured at the if that lengths match
+        Ok(params.h.mul(r) + C::msm_unchecked(&params.generators[..a.len()], a))
+    }
+
+    pub fn prove(
+        params: &PedersenParams<C>,
+        a: &[C::ScalarField],
+        // b: &[C::ScalarField],
+        x: &C::ScalarField,
+        u: &[C::ScalarField],
+        U: &C,
+        l: &Vec<C::ScalarField>, // blinding factor
+        r: &Vec<C::ScalarField>, // blinding factor
+    ) -> Result<Proof<C>, Error> {
+        // TODO 'a' must be a power of two
+        let d = a.len();
+        let k = (f64::from(d as u32).log2()) as usize;
+
+        if params.generators.len() < a.len() {
+            return Err(Error::PedersenParamsLen(params.generators.len(), a.len()));
+        }
+        // if a.len() != b.len() {
+        //     return Err(Error::NotSameLength(
+        //         "a".to_string(),
+        //         a.len(),
+        //         "b".to_string(),
+        //         b.len(),
+        //     ));
+        // }
+        if l.len() != k {
+            return Err(Error::NotExpectedLength(l.len(), k));
+        }
+        if r.len() != k {
+            return Err(Error::NotExpectedLength(r.len(), k));
+        }
+
+        let mut a = a.to_owned();
+        // let mut b = b.to_owned();
+        let mut b = powers_of(*x, d);
+        let mut G = params.generators.clone();
+
+        let mut L: Vec<C> = vec![C::zero(); k];
+        let mut R: Vec<C> = vec![C::zero(); k];
+
+        for j in (0..k).rev() {
+            let m = a.len() / 2;
+            let a_lo = a[..m].to_vec();
+            let a_hi = a[m..].to_vec();
+            let b_lo = b[..m].to_vec();
+            let b_hi = b[m..].to_vec();
+            let G_lo = G[..m].to_vec();
+            let G_hi = G[m..].to_vec();
+
+            L[j] = C::msm_unchecked(&G_hi, &a_lo)
+                + params.h.mul(l[j])
+                + U.mul(inner_prod(&a_lo, &b_hi)?);
+            R[j] = C::msm_unchecked(&G_lo, &a_hi)
+                + params.h.mul(r[j])
+                + U.mul(inner_prod(&a_hi, &b_lo)?);
+
+            let uj = u[j];
+            let uj_inv = u[j].inverse().unwrap();
+
+            // a_hi * uj^-1 + a_lo * uj
+            a = vec_add(&vec_scalar_mul(&a_lo, &uj), &vec_scalar_mul(&a_hi, &uj_inv))?;
+            // b_lo * uj^-1 + b_hi * uj
+            b = vec_add(&vec_scalar_mul(&b_lo, &uj_inv), &vec_scalar_mul(&b_hi, &uj))?;
+            // G_lo * uj^-1 + G_hi * uj
+            G = G_lo
+                .iter()
+                .map(|e| e.into_group().mul(uj_inv))
+                .collect::<Vec<C>>()
+                .iter()
+                .zip(
+                    G_hi.iter()
+                        .map(|e| e.into_group().mul(uj))
+                        .collect::<Vec<C>>()
+                        .iter(),
+                )
+                .map(|(a, b)| (*a + *b).into_affine())
+                .collect::<Vec<C::Affine>>();
+        }
+
+        if a.len() != 1 {
+            return Err(Error::NotExpectedLength(a.len(), 1));
+        }
+        if b.len() != 1 {
+            return Err(Error::NotExpectedLength(b.len(), 1));
+        }
+        if G.len() != 1 {
+            return Err(Error::NotExpectedLength(G.len(), 1));
+        }
+
+        Ok(Proof {
+            a: a[0],
+            l: l.clone(), // TODO rm clone
+            r: r.clone(),
+            L,
+            R,
+        })
+    }
+    pub fn verify(
+        params: &PedersenParams<C>,
+        x: &C::ScalarField, // evaluation point
+        v: &C::ScalarField, // value at evaluation point
+        P: &C,              // commitment
+        p: &Proof<C>,
+        r: &C::ScalarField,   // blinding factor
+        u: &[C::ScalarField], // challenges
+        U: &C,                // challenge
+        d: usize,
+    ) -> Result<bool, Error> {
+        let P = *P + U.mul(v);
+
+        let mut q_0 = P;
+        let mut r = *r;
+
+        // compute b & G from s
+        let s = build_s(u, d);
+        let bs = powers_of(*x, d);
+        let b = inner_prod(&s, &bs)?;
+        if params.generators.len() < s.len() {
+            // TODO check if maybe use msm (no-unchecked) and avoid this if
+            return Err(Error::PedersenParamsLen(params.generators.len(), s.len()));
+        }
+        let G = C::msm_unchecked(&params.generators, &s);
+
+        #[allow(clippy::needless_range_loop)]
+        for j in 0..u.len() {
+            let uj2 = u[j].square();
+            let uj_inv2 = u[j].inverse().unwrap().square();
+
+            q_0 = q_0 + p.L[j].mul(uj2) + p.R[j].mul(uj_inv2);
+            r = r + p.l[j] * uj2 + p.r[j] * uj_inv2;
+        }
+
+        let q_1 = G.mul(p.a) + params.h.mul(r) + U.mul(p.a * b);
+
+        Ok(q_0 == q_1)
+    }
+}
+
+// s = (
+//   u₁⁻¹ u₂⁻¹ … uₖ⁻¹,
+//   u₁   u₂⁻¹ … uₖ⁻¹,
+//   u₁⁻¹ u₂   … uₖ⁻¹,
+//   u₁   u₂   … uₖ⁻¹,
+//   ⋮    ⋮      ⋮
+//   u₁   u₂   … uₖ
+// )
+fn build_s<F: PrimeField>(u: &[F], d: usize) -> Vec<F> {
+    let k = (f64::from(d as u32).log2()) as usize;
+    let mut s: Vec<F> = vec![F::one(); d];
+    let mut t = d;
+    for j in (0..k).rev() {
+        t /= 2;
+        let mut c = 0;
+        for i in 0..d {
+            if c < t {
+                s[i] *= u[j].inverse().unwrap();
+            } else {
+                s[i] *= u[j];
+            }
+            c += 1;
+            if c >= t * 2 {
+                c = 0;
+            }
+        }
+    }
+    s
+}
+
+// TODO next 3 are WIP
+fn inner_prod<F: PrimeField>(a: &[F], b: &[F]) -> Result<F, Error> {
+    if a.len() != b.len() {
+        return Err(Error::NotSameLength(
+            "a".to_string(),
+            a.len(),
+            "b".to_string(),
+            b.len(),
+        ));
+    }
+    let mut c: F = F::zero();
+    for i in 0..a.len() {
+        c += a[i] * b[i];
+    }
+    Ok(c)
+}
+fn powers_of<F: PrimeField>(x: F, d: usize) -> Vec<F> {
+    // TODO do the efficient way
+    let mut c: Vec<F> = vec![F::zero(); d];
+    c[0] = x;
+    for i in 1..d {
+        c[i] = c[i - 1] * x;
+    }
+    c
+}
+
+#[cfg(test)]
+mod tests {
+    use ark_pallas::{constraints::GVar, Fq, Fr, Projective};
+    use ark_r1cs_std::{alloc::AllocVar, bits::boolean::Boolean, eq::EqGadget};
+    use ark_relations::r1cs::ConstraintSystem;
+    use ark_std::UniformRand;
+
+    use super::*;
+    use crate::commitment::pedersen::Pedersen;
+    // use crate::transcript::poseidon::{poseidon_test_config, PoseidonTranscript};
+
+    #[test]
+    fn test_ipa() {
+        let mut rng = ark_std::test_rng();
+
+        let d: usize = 16;
+        let k = (f64::from(d as u32).log2()) as usize;
+        // setup params
+        let params = Pedersen::<Projective>::new_params(&mut rng, d); // TODO move to IPA::new_params
+
+        // let poseidon_config = poseidon_test_config::<Fr>();
+        // // init Prover's transcript
+        // let mut transcript_p = PoseidonTranscript::<Projective>::new(&poseidon_config);
+        // // init Verifier's transcript
+        // let mut transcript_v = PoseidonTranscript::<Projective>::new(&poseidon_config);
+
+        let a: Vec<Fr> = std::iter::repeat_with(|| Fr::rand(&mut rng))
+            .take(d)
+            .collect();
+        let r_blind: Fr = Fr::rand(&mut rng);
+        let cm = IPA::<Projective>::commit(&params, &a, &r_blind).unwrap();
+
+        // blinding factors
+        let l: Vec<Fr> = std::iter::repeat_with(|| Fr::rand(&mut rng))
+            .take(k)
+            .collect();
+        let r: Vec<Fr> = std::iter::repeat_with(|| Fr::rand(&mut rng))
+            .take(k)
+            .collect();
+
+        // random challenges
+        let u: Vec<Fr> = std::iter::repeat_with(|| Fr::rand(&mut rng))
+            .take(k)
+            .collect();
+        let U = Projective::rand(&mut rng);
+
+        // evaluation point
+        let x = Fr::rand(&mut rng);
+
+        let proof = IPA::<Projective>::prove(&params, &a, &x, &u, &U, &l, &r).unwrap();
+
+        let b = powers_of(x, d); // WIP
+        let v = inner_prod(&a, &b).unwrap(); // WIP
+        assert!(
+            IPA::<Projective>::verify(&params, &x, &v, &cm, &proof, &r_blind, &u, &U, d).unwrap()
+        );
+    }
+}

--- a/folding-schemes/src/commitment/kzg.rs
+++ b/folding-schemes/src/commitment/kzg.rs
@@ -66,11 +66,11 @@ where
 
 /// KZGProver implements the CommitmentProver trait for the KZG commitment scheme.
 #[derive(Debug, Clone, Default, Eq, PartialEq)]
-pub struct KZGProver<'a, C: CurveGroup, const BLIND: bool = false> {
+pub struct KZGProver<'a, C: CurveGroup, const H: bool = false> {
     _a: PhantomData<&'a ()>,
     _c: PhantomData<C>,
 }
-impl<'a, C, const BLIND: bool> CommitmentProver<C, BLIND> for KZGProver<'a, C, BLIND>
+impl<'a, C, const H: bool> CommitmentProver<C, H> for KZGProver<'a, C, H>
 where
     C: CurveGroup,
 {
@@ -87,8 +87,8 @@ where
         v: &[C::ScalarField],
         _blind: &C::ScalarField,
     ) -> Result<C, Error> {
-        if !_blind.is_zero() || BLIND {
-            return Err(Error::NotSupportedYet("blinding".to_string()));
+        if !_blind.is_zero() || H {
+            return Err(Error::NotSupportedYet("hiding".to_string()));
         }
 
         let polynomial = poly_from_vec(v.to_vec())?;
@@ -115,8 +115,8 @@ where
         _blind: &C::ScalarField,
         _rng: Option<&mut dyn RngCore>,
     ) -> Result<Self::Proof, Error> {
-        if !_blind.is_zero() || BLIND {
-            return Err(Error::NotSupportedYet("blinding".to_string()));
+        if !_blind.is_zero() || H {
+            return Err(Error::NotSupportedYet("hiding".to_string()));
         }
 
         let polynomial = poly_from_vec(v.to_vec())?;

--- a/folding-schemes/src/commitment/kzg.rs
+++ b/folding-schemes/src/commitment/kzg.rs
@@ -17,7 +17,7 @@ use ark_poly::{
     DenseUVPolynomial, EvaluationDomain, Evaluations, GeneralEvaluationDomain, Polynomial,
 };
 use ark_poly_commit::kzg10::{VerifierKey, KZG10};
-use ark_std::rand::Rng;
+use ark_std::rand::{Rng, RngCore};
 use ark_std::{borrow::Cow, fmt::Debug};
 use ark_std::{One, Zero};
 use core::marker::PhantomData;
@@ -66,11 +66,11 @@ where
 
 /// KZGProver implements the CommitmentProver trait for the KZG commitment scheme.
 #[derive(Debug, Clone, Default, Eq, PartialEq)]
-pub struct KZGProver<'a, C: CurveGroup> {
+pub struct KZGProver<'a, C: CurveGroup, const BLIND: bool = false> {
     _a: PhantomData<&'a ()>,
     _c: PhantomData<C>,
 }
-impl<'a, C> CommitmentProver<C> for KZGProver<'a, C>
+impl<'a, C, const BLIND: bool> CommitmentProver<C, BLIND> for KZGProver<'a, C, BLIND>
 where
     C: CurveGroup,
 {
@@ -87,8 +87,8 @@ where
         v: &[C::ScalarField],
         _blind: &C::ScalarField,
     ) -> Result<C, Error> {
-        if !_blind.is_zero() {
-            return Err(Error::NotSupportedYet("blinding factors".to_string()));
+        if !_blind.is_zero() || BLIND {
+            return Err(Error::NotSupportedYet("blinding".to_string()));
         }
 
         let polynomial = poly_from_vec(v.to_vec())?;
@@ -113,9 +113,10 @@ where
         cm: &C,
         v: &[C::ScalarField],
         _blind: &C::ScalarField,
+        _rng: Option<&mut dyn RngCore>,
     ) -> Result<Self::Proof, Error> {
-        if !_blind.is_zero() {
-            return Err(Error::NotSupportedYet("blinding factors".to_string()));
+        if !_blind.is_zero() || BLIND {
+            return Err(Error::NotSupportedYet("blinding".to_string()));
         }
 
         let polynomial = poly_from_vec(v.to_vec())?;
@@ -213,7 +214,7 @@ mod tests {
         let cm = KZGProver::<G1>::commit(&pk, &v, &Fr::zero()).unwrap();
 
         let (eval, proof) =
-            KZGProver::<G1>::prove(&pk, transcript_p, &cm, &v, &Fr::zero()).unwrap();
+            KZGProver::<G1>::prove(&pk, transcript_p, &cm, &v, &Fr::zero(), None).unwrap();
 
         // verify the proof:
         // get evaluation challenge

--- a/folding-schemes/src/commitment/mod.rs
+++ b/folding-schemes/src/commitment/mod.rs
@@ -4,6 +4,7 @@ use ark_std::fmt::Debug;
 use crate::transcript::Transcript;
 use crate::Error;
 
+pub mod ipa;
 pub mod kzg;
 pub mod pedersen;
 

--- a/folding-schemes/src/commitment/mod.rs
+++ b/folding-schemes/src/commitment/mod.rs
@@ -9,8 +9,9 @@ pub mod ipa;
 pub mod kzg;
 pub mod pedersen;
 
-/// CommitmentProver defines the vector commitment scheme prover trait.
-pub trait CommitmentProver<C: CurveGroup, const BLIND: bool = false>: Clone + Debug {
+/// CommitmentProver defines the vector commitment scheme prover trait. Where `H` indicates if to
+/// use the commitment in hiding mode or not.
+pub trait CommitmentProver<C: CurveGroup, const H: bool = false>: Clone + Debug {
     type Params: Clone + Debug;
     type Proof: Clone + Debug;
 

--- a/folding-schemes/src/commitment/pedersen.rs
+++ b/folding-schemes/src/commitment/pedersen.rs
@@ -239,6 +239,5 @@ mod tests {
         // use the gadget
         let cmVar = PedersenGadget::<Projective, GVar>::commit(hVar, gVar, vVar, rVar).unwrap();
         cmVar.enforce_equal(&expected_cmVar).unwrap();
-        dbg!(cs.num_constraints());
     }
 }

--- a/folding-schemes/src/folding/hypernova/cccs.rs
+++ b/folding-schemes/src/folding/hypernova/cccs.rs
@@ -112,7 +112,7 @@ impl<C: CurveGroup> CCCS<C> {
     ) -> Result<(), Error> {
         // check that C is the commitment of w. Notice that this is not verifying a Pedersen
         // opening, but checking that the commitment comes from committing to the witness.
-        if self.C != Pedersen::commit(pedersen_params, &w.w, &w.r_w)? {
+        if self.C != Pedersen::<C>::commit(pedersen_params, &w.w, &w.r_w)? {
             return Err(Error::NotSatisfied);
         }
 

--- a/folding-schemes/src/folding/hypernova/circuit.rs
+++ b/folding-schemes/src/folding/hypernova/circuit.rs
@@ -180,7 +180,7 @@ mod tests {
         let r_x_prime: Vec<Fr> = (0..ccs.s).map(|_| Fr::rand(&mut rng)).collect();
 
         // Initialize a multifolding object
-        let pedersen_params = Pedersen::new_params(&mut rng, ccs.n - ccs.l - 1);
+        let pedersen_params = Pedersen::<Projective>::new_params(&mut rng, ccs.n - ccs.l - 1);
         let (lcccs_instance, _) = ccs.to_lcccs(&mut rng, &pedersen_params, &z1).unwrap();
         let sigmas_thetas =
             compute_sigmas_and_thetas(&ccs, &[z1.clone()], &[z2.clone()], &r_x_prime);
@@ -224,7 +224,7 @@ mod tests {
         let r_x_prime: Vec<Fr> = (0..ccs.s).map(|_| Fr::rand(&mut rng)).collect();
 
         // Initialize a multifolding object
-        let pedersen_params = Pedersen::new_params(&mut rng, ccs.n - ccs.l - 1);
+        let pedersen_params = Pedersen::<Projective>::new_params(&mut rng, ccs.n - ccs.l - 1);
         let (lcccs_instance, _) = ccs.to_lcccs(&mut rng, &pedersen_params, &z1).unwrap();
         let sigmas_thetas =
             compute_sigmas_and_thetas(&ccs, &[z1.clone()], &[z2.clone()], &r_x_prime);
@@ -267,7 +267,7 @@ mod tests {
         let r_x_prime: Vec<Fr> = (0..ccs.s).map(|_| Fr::rand(&mut rng)).collect();
 
         // Initialize a multifolding object
-        let pedersen_params = Pedersen::new_params(&mut rng, ccs.n - ccs.l - 1);
+        let pedersen_params = Pedersen::<Projective>::new_params(&mut rng, ccs.n - ccs.l - 1);
         let (lcccs_instance, _) = ccs.to_lcccs(&mut rng, &pedersen_params, &z1).unwrap();
         let sigmas_thetas =
             compute_sigmas_and_thetas(&ccs, &[z1.clone()], &[z2.clone()], &r_x_prime);

--- a/folding-schemes/src/folding/hypernova/lcccs.rs
+++ b/folding-schemes/src/folding/hypernova/lcccs.rs
@@ -46,7 +46,7 @@ impl<C: CurveGroup> CCS<C> {
     ) -> Result<(LCCCS<C>, Witness<C::ScalarField>), Error> {
         let w: Vec<C::ScalarField> = z[(1 + self.l)..].to_vec();
         let r_w = C::ScalarField::rand(rng);
-        let C = Pedersen::commit(pedersen_params, &w, &r_w)?;
+        let C = Pedersen::<C>::commit(pedersen_params, &w, &r_w)?;
 
         let r_x: Vec<C::ScalarField> = (0..self.s).map(|_| C::ScalarField::rand(rng)).collect();
         let v = self.compute_v_j(z, &r_x);
@@ -96,8 +96,8 @@ impl<C: CurveGroup> LCCCS<C> {
         w: &Witness<C::ScalarField>,
     ) -> Result<(), Error> {
         // check that C is the commitment of w. Notice that this is not verifying a Pedersen
-        // opening, but checking that the commitment comes from committing to the witness.
-        if self.C != Pedersen::commit(pedersen_params, &w.w, &w.r_w)? {
+        // opening, but checking that the Commmitment comes from committing to the witness.
+        if self.C != Pedersen::<C>::commit(pedersen_params, &w.w, &w.r_w)? {
             return Err(Error::NotSatisfied);
         }
 

--- a/folding-schemes/src/folding/hypernova/nimfs.rs
+++ b/folding-schemes/src/folding/hypernova/nimfs.rs
@@ -430,7 +430,7 @@ pub mod tests {
 
         // Create a basic CCS circuit
         let ccs = get_test_ccs::<Projective>();
-        let pedersen_params = Pedersen::new_params(&mut rng, ccs.n - ccs.l - 1);
+        let pedersen_params = Pedersen::<Projective>::new_params(&mut rng, ccs.n - ccs.l - 1);
 
         // Generate a satisfying witness
         let z_1 = get_test_z(3);
@@ -489,7 +489,7 @@ pub mod tests {
 
         let ccs = get_test_ccs::<Projective>();
 
-        let pedersen_params = Pedersen::new_params(&mut rng, ccs.n - ccs.l - 1);
+        let pedersen_params = Pedersen::<Projective>::new_params(&mut rng, ccs.n - ccs.l - 1);
 
         // LCCCS witness
         let z_1 = get_test_z(2);
@@ -557,7 +557,7 @@ pub mod tests {
 
         // Create a basic CCS circuit
         let ccs = get_test_ccs::<Projective>();
-        let pedersen_params = Pedersen::new_params(&mut rng, ccs.n - ccs.l - 1);
+        let pedersen_params = Pedersen::<Projective>::new_params(&mut rng, ccs.n - ccs.l - 1);
 
         let mu = 10;
         let nu = 15;
@@ -639,7 +639,7 @@ pub mod tests {
 
         // Create a basic CCS circuit
         let ccs = get_test_ccs::<Projective>();
-        let pedersen_params = Pedersen::new_params(&mut rng, ccs.n - ccs.l - 1);
+        let pedersen_params = Pedersen::<Projective>::new_params(&mut rng, ccs.n - ccs.l - 1);
 
         let poseidon_config = poseidon_test_config::<Fr>();
         // Prover's transcript

--- a/folding-schemes/src/folding/hypernova/utils.rs
+++ b/folding-schemes/src/folding/hypernova/utils.rs
@@ -290,7 +290,7 @@ pub mod tests {
         let r_x_prime: Vec<Fr> = (0..ccs.s).map(|_| Fr::rand(&mut rng)).collect();
 
         // Initialize a multifolding object
-        let pedersen_params = Pedersen::new_params(&mut rng, ccs.n - ccs.l - 1);
+        let pedersen_params = Pedersen::<Projective>::new_params(&mut rng, ccs.n - ccs.l - 1);
         let (lcccs_instance, _) = ccs.to_lcccs(&mut rng, &pedersen_params, &z1).unwrap();
 
         let sigmas_thetas =
@@ -333,7 +333,7 @@ pub mod tests {
         let beta: Vec<Fr> = (0..ccs.s).map(|_| Fr::rand(&mut rng)).collect();
 
         // Initialize a multifolding object
-        let pedersen_params = Pedersen::new_params(&mut rng, ccs.n - ccs.l - 1);
+        let pedersen_params = Pedersen::<Projective>::new_params(&mut rng, ccs.n - ccs.l - 1);
         let (lcccs_instance, _) = ccs.to_lcccs(&mut rng, &pedersen_params, &z1).unwrap();
 
         let mut sum_v_j_gamma = Fr::zero();

--- a/folding-schemes/src/folding/nova/circuits.rs
+++ b/folding-schemes/src/folding/nova/circuits.rs
@@ -654,7 +654,6 @@ pub mod tests {
             .generate_constraints(cs.clone())
             .unwrap();
         cs.finalize();
-        println!("num_constraints={:?}", cs.num_constraints());
         let cs = cs.into_inner().unwrap();
         let r1cs = extract_r1cs::<Fr>(&cs);
         let (w, x) = extract_w_x::<Fr>(&cs);

--- a/folding-schemes/src/folding/nova/cyclefold.rs
+++ b/folding-schemes/src/folding/nova/cyclefold.rs
@@ -459,7 +459,6 @@ pub mod tests {
         .unwrap();
         nifs_cf_check.enforce_equal(&Boolean::<Fq>::TRUE).unwrap();
         assert!(cs.is_satisfied().unwrap());
-        dbg!(cs.num_constraints());
     }
 
     #[test]
@@ -500,7 +499,6 @@ pub mod tests {
         .unwrap();
         nifs_check.enforce_equal(&Boolean::<Fq>::TRUE).unwrap();
         assert!(cs.is_satisfied().unwrap());
-        dbg!(cs.num_constraints());
     }
 
     #[test]

--- a/folding-schemes/src/folding/nova/decider_eth_circuit.rs
+++ b/folding-schemes/src/folding/nova/decider_eth_circuit.rs
@@ -670,6 +670,5 @@ pub mod tests {
         // generate the constraints and check that are satisfied by the inputs
         decider_circuit.generate_constraints(cs.clone()).unwrap();
         assert!(cs.is_satisfied().unwrap());
-        dbg!(cs.num_constraints());
     }
 }

--- a/folding-schemes/src/folding/nova/nifs.rs
+++ b/folding-schemes/src/folding/nova/nifs.rs
@@ -190,9 +190,9 @@ where
         T: Vec<C::ScalarField>,
         cmT: &C,
     ) -> Result<[CP::Proof; 3], Error> {
-        let cmE_proof = CP::prove(cm_prover_params, tr, &ci.cmE, &w.E, &w.rE)?;
-        let cmW_proof = CP::prove(cm_prover_params, tr, &ci.cmW, &w.W, &w.rW)?;
-        let cmT_proof = CP::prove(cm_prover_params, tr, cmT, &T, &C::ScalarField::one())?; // cm(T) is committed with rT=1
+        let cmE_proof = CP::prove(cm_prover_params, tr, &ci.cmE, &w.E, &w.rE, None)?;
+        let cmW_proof = CP::prove(cm_prover_params, tr, &ci.cmW, &w.W, &w.rW, None)?;
+        let cmT_proof = CP::prove(cm_prover_params, tr, cmT, &T, &C::ScalarField::one(), None)?; // cm(T) is committed with rT=1
         Ok([cmE_proof, cmW_proof, cmT_proof])
     }
 }

--- a/folding-schemes/src/folding/protogalaxy/folding.rs
+++ b/folding-schemes/src/folding/protogalaxy/folding.rs
@@ -18,7 +18,8 @@ use super::{CommittedInstance, Witness};
 
 use crate::ccs::r1cs::R1CS;
 use crate::transcript::Transcript;
-use crate::utils::{bit::bit_decompose, vec::*};
+use crate::utils::vec::*;
+use crate::utils::virtual_polynomial::bit_decompose;
 use crate::Error;
 
 #[derive(Clone, Debug)]

--- a/folding-schemes/src/lib.rs
+++ b/folding-schemes/src/lib.rs
@@ -40,6 +40,8 @@ pub enum Error {
     NotSameLength(String, usize, String, usize),
     #[error("Vector's length ({0}) is not the expected ({1})")]
     NotExpectedLength(usize, usize),
+    #[error("Vector ({0}) length ({1}) is a power of two")]
+    NotPowerOfTwo(String, usize),
     #[error("Can not be empty")]
     Empty,
     #[error("Pedersen parameters length is not sufficient (generators.len={0} < vector.len={1} unsatisfied)")]

--- a/folding-schemes/src/lib.rs
+++ b/folding-schemes/src/lib.rs
@@ -46,6 +46,8 @@ pub enum Error {
     Empty,
     #[error("Pedersen parameters length is not sufficient (generators.len={0} < vector.len={1} unsatisfied)")]
     PedersenParamsLen(usize, usize),
+    #[error("Randomness for blinding not found")]
+    MissingRandomness,
     #[error("Commitment verification failed")]
     CommitmentVerificationFail,
     #[error("IVC verification failed")]

--- a/folding-schemes/src/lib.rs
+++ b/folding-schemes/src/lib.rs
@@ -40,7 +40,7 @@ pub enum Error {
     NotSameLength(String, usize, String, usize),
     #[error("Vector's length ({0}) is not the expected ({1})")]
     NotExpectedLength(usize, usize),
-    #[error("Vector ({0}) length ({1}) is a power of two")]
+    #[error("Vector ({0}) length ({1}) is not a power of two")]
     NotPowerOfTwo(String, usize),
     #[error("Can not be empty")]
     Empty,

--- a/folding-schemes/src/utils/bit.rs
+++ b/folding-schemes/src/utils/bit.rs
@@ -1,9 +1,0 @@
-pub fn bit_decompose(input: u64, n: usize) -> Vec<bool> {
-    let mut res = Vec::with_capacity(n);
-    let mut i = input;
-    for _ in 0..n {
-        res.push(i & 1 == 1);
-        i >>= 1;
-    }
-    res
-}

--- a/folding-schemes/src/utils/mod.rs
+++ b/folding-schemes/src/utils/mod.rs
@@ -1,4 +1,3 @@
-pub mod bit;
 pub mod gadgets;
 pub mod hypercube;
 pub mod lagrange_poly;

--- a/folding-schemes/src/utils/mod.rs
+++ b/folding-schemes/src/utils/mod.rs
@@ -1,3 +1,5 @@
+use ark_ff::PrimeField;
+
 pub mod gadgets;
 pub mod hypercube;
 pub mod lagrange_poly;
@@ -9,3 +11,13 @@ pub mod espresso;
 pub use crate::utils::espresso::multilinear_polynomial;
 pub use crate::utils::espresso::sum_check;
 pub use crate::utils::espresso::virtual_polynomial;
+
+/// For a given x, returns [1, x^1, x^2, ..., x^n-1];
+pub fn powers_of<F: PrimeField>(x: F, n: usize) -> Vec<F> {
+    let mut c: Vec<F> = vec![F::zero(); n];
+    c[0] = F::one();
+    for i in 1..n {
+        c[i] = c[i - 1] * x;
+    }
+    c
+}


### PR DESCRIPTION
Add IPA commitment scheme and implement the verifier circuit.
Also modifies the CommitmentProver trait to have the `H` constant parameter, which basically selects if to use or not the hiding version of the commitment.

I didn't had this planned, but started to go down the IPA path trying to get down the number of constraints for the Onchain-Decider circuit (for the cyclefold instance commitments verification). But even with the last optimizations is cheaper to just go with naive Pedersen verification (by little amount of constraints).
But anyways, the IPA verifier can be amoritzed and in the offchain-decider we can amoritze the verification of the 4 commitments (from main Nova u & U instances), so seems still worth it.
