### PR TITLE
Fix Nova multi-elements state

### DIFF
--- a/folding-schemes/examples/multi_inputs.rs
+++ b/folding-schemes/examples/multi_inputs.rs
@@ -18,7 +18,7 @@ use folding_schemes::folding::nova::Nova;
 use folding_schemes::frontend::FCircuit;
 use folding_schemes::{Error, FoldingScheme};
 mod utils;
-use utils::nova_setup;
+use utils::test_nova_setup;
 
 /// This is the circuit that we want to fold, it implements the FCircuit trait. The parameter z_i
 /// denotes the current state which contains 5 elements, and z_{i+1} denotes the next state which
@@ -115,7 +115,7 @@ fn main() {
     let F_circuit = MultiInputsFCircuit::<Fr>::new(());
 
     println!("Prepare Nova ProverParams & VerifierParams");
-    let (prover_params, verifier_params) = nova_setup::<MultiInputsFCircuit<Fr>>(F_circuit);
+    let (prover_params, verifier_params) = test_nova_setup::<MultiInputsFCircuit<Fr>>(F_circuit);
 
     /// The idea here is that eventually we could replace the next line chunk that defines the
     /// `type NOVA = Nova<...>` by using another folding scheme that fulfills the `FoldingScheme`

--- a/folding-schemes/examples/multi_inputs.rs
+++ b/folding-schemes/examples/multi_inputs.rs
@@ -26,10 +26,10 @@ use utils::nova_setup;
 /// In this example we set z_i and z_{i+1} to have five elements, and at each step we do different
 /// operations on each of them.
 #[derive(Clone, Copy, Debug)]
-pub struct MultipleAddFCircuit<F: PrimeField> {
+pub struct MultiInputsFCircuit<F: PrimeField> {
     _f: PhantomData<F>,
 }
-impl<F: PrimeField> FCircuit<F> for MultipleAddFCircuit<F> {
+impl<F: PrimeField> FCircuit<F> for MultiInputsFCircuit<F> {
     type Params = ();
 
     fn new(_params: Self::Params) -> Self {
@@ -70,19 +70,19 @@ impl<F: PrimeField> FCircuit<F> for MultipleAddFCircuit<F> {
     }
 }
 
-/// cargo test --example multiple-inputs
+/// cargo test --example multi_inputs
 #[cfg(test)]
 pub mod tests {
     use super::*;
     use ark_r1cs_std::alloc::AllocVar;
     use ark_relations::r1cs::ConstraintSystem;
 
-    // test to check that the MultipleAddFCircuit computes the same values inside and outside the circuit
+    // test to check that the MultiInputsFCircuit computes the same values inside and outside the circuit
     #[test]
     fn test_add_f_circuit() {
         let cs = ConstraintSystem::<Fr>::new_ref();
 
-        let circuit = MultipleAddFCircuit::<Fr>::new(());
+        let circuit = MultiInputsFCircuit::<Fr>::new(());
         let z_i = vec![
             Fr::from(1_u32),
             Fr::from(1_u32),
@@ -101,7 +101,7 @@ pub mod tests {
     }
 }
 
-/// cargo run --release --example multiple_inputs
+/// cargo run --release --example multi_inputs
 fn main() {
     let num_steps = 10;
     let initial_state = vec![
@@ -112,10 +112,10 @@ fn main() {
         Fr::from(1_u32),
     ];
 
-    let F_circuit = MultipleAddFCircuit::<Fr>::new(());
+    let F_circuit = MultiInputsFCircuit::<Fr>::new(());
 
     println!("Prepare Nova ProverParams & VerifierParams");
-    let (prover_params, verifier_params) = nova_setup::<MultipleAddFCircuit<Fr>>(F_circuit);
+    let (prover_params, verifier_params) = nova_setup::<MultiInputsFCircuit<Fr>>(F_circuit);
 
     /// The idea here is that eventually we could replace the next line chunk that defines the
     /// `type NOVA = Nova<...>` by using another folding scheme that fulfills the `FoldingScheme`
@@ -125,7 +125,7 @@ fn main() {
         GVar,
         Projective2,
         GVar2,
-        MultipleAddFCircuit<Fr>,
+        MultiInputsFCircuit<Fr>,
         Pedersen<Projective>,
         Pedersen<Projective2>,
     >;

--- a/folding-schemes/examples/multiple_inputs.rs
+++ b/folding-schemes/examples/multiple_inputs.rs
@@ -3,15 +3,9 @@
 #![allow(non_camel_case_types)]
 #![allow(clippy::upper_case_acronyms)]
 
-use ark_crypto_primitives::crh::{
-    sha256::{
-        constraints::{Sha256Gadget, UnitVar},
-        Sha256,
-    },
-    CRHScheme, CRHSchemeGadget,
-};
-use ark_ff::{BigInteger, PrimeField, ToConstraintField};
-use ark_r1cs_std::{fields::fp::FpVar, ToBytesGadget, ToConstraintFieldGadget};
+use ark_ff::PrimeField;
+use ark_r1cs_std::alloc::AllocVar;
+use ark_r1cs_std::fields::fp::FpVar;
 use ark_relations::r1cs::{ConstraintSystemRef, SynthesisError};
 use core::marker::PhantomData;
 use std::time::Instant;
@@ -25,41 +19,53 @@ use folding_schemes::frontend::FCircuit;
 use folding_schemes::transcript::poseidon::poseidon_test_config;
 use folding_schemes::{Error, FoldingScheme};
 
-/// This is the circuit that we want to fold, it implements the FCircuit trait.
-/// The parameter z_i denotes the current state, and z_{i+1} denotes the next state which we get by
-/// applying the step.
-/// In this example we set z_i and z_{i+1} to be a single value, but the trait is made to support
-/// arrays, so our state could be an array with different values.
+/// This is the circuit that we want to fold, it implements the FCircuit trait. The parameter z_i
+/// denotes the current state which contains 5 elements, and z_{i+1} denotes the next state which
+/// we get by applying the step.
+/// In this example we set z_i and z_{i+1} to have five elements, and at each step we do different
+/// operations on each of them.
 #[derive(Clone, Copy, Debug)]
-pub struct Sha256FCircuit<F: PrimeField> {
+pub struct MultipleAddFCircuit<F: PrimeField> {
     _f: PhantomData<F>,
 }
-impl<F: PrimeField> FCircuit<F> for Sha256FCircuit<F> {
+impl<F: PrimeField> FCircuit<F> for MultipleAddFCircuit<F> {
     type Params = ();
 
     fn new(_params: Self::Params) -> Self {
         Self { _f: PhantomData }
     }
+    fn state_len(self) -> usize {
+        5
+    }
 
     /// computes the next state values in place, assigning z_{i+1} into z_i, and computing the new
     /// z_{i+1}
     fn step_native(self, z_i: Vec<F>) -> Result<Vec<F>, Error> {
-        let out_bytes = Sha256::evaluate(&(), z_i[0].into_bigint().to_bytes_le()).unwrap();
-        let out: Vec<F> = out_bytes.to_field_elements().unwrap();
+        let a = z_i[0] + F::from(4_u32);
+        let b = z_i[1] + F::from(40_u32);
+        let c = z_i[2] * F::from(4_u32);
+        let d = z_i[3] * F::from(40_u32);
+        let e = z_i[4] + F::from(100_u32);
 
-        Ok(vec![out[0]])
+        Ok(vec![a, b, c, d, e])
     }
 
     /// generates the constraints for the step of F for the given z_i
     fn generate_step_constraints(
         self,
-        _cs: ConstraintSystemRef<F>,
+        cs: ConstraintSystemRef<F>,
         z_i: Vec<FpVar<F>>,
     ) -> Result<Vec<FpVar<F>>, SynthesisError> {
-        let unit_var = UnitVar::default();
-        let out_bytes = Sha256Gadget::evaluate(&unit_var, &z_i[0].to_bytes()?)?;
-        let out = out_bytes.0.to_constraint_field()?;
-        Ok(vec![out[0].clone()])
+        let four = FpVar::<F>::new_constant(cs.clone(), F::from(4u32))?;
+        let fourty = FpVar::<F>::new_constant(cs.clone(), F::from(40u32))?;
+        let onehundred = FpVar::<F>::new_constant(cs.clone(), F::from(100u32))?;
+        let a = z_i[0].clone() + four.clone();
+        let b = z_i[1].clone() + fourty.clone();
+        let c = z_i[2].clone() * four;
+        let d = z_i[3].clone() * fourty;
+        let e = z_i[4].clone() + onehundred;
+
+        Ok(vec![a, b, c, d, e])
     }
 }
 
@@ -70,13 +76,19 @@ pub mod tests {
     use ark_r1cs_std::alloc::AllocVar;
     use ark_relations::r1cs::ConstraintSystem;
 
-    // test to check that the Sha256FCircuit computes the same values inside and outside the circuit
+    // test to check that the MultipleAddFCircuit computes the same values inside and outside the circuit
     #[test]
-    fn test_sha256_f_circuit() {
+    fn test_add_f_circuit() {
         let cs = ConstraintSystem::<Fr>::new_ref();
 
-        let circuit = Sha256FCircuit::<Fr>::new(());
-        let z_i = vec![Fr::from(1_u32)];
+        let circuit = MultipleAddFCircuit::<Fr>::new(());
+        let z_i = vec![
+            Fr::from(1_u32),
+            Fr::from(1_u32),
+            Fr::from(1_u32),
+            Fr::from(1_u32),
+            Fr::from(1_u32),
+        ];
 
         let z_i1 = circuit.step_native(z_i.clone()).unwrap();
 
@@ -123,15 +135,21 @@ fn nova_setup<FC: FCircuit<Fr>>(
     (prover_params, verifier_params)
 }
 
-/// cargo run --release --example fold_sha256
+/// cargo run --release --example multiple_inputs
 fn main() {
     let num_steps = 10;
-    let initial_state = vec![Fr::from(1_u32)];
+    let initial_state = vec![
+        Fr::from(1_u32),
+        Fr::from(1_u32),
+        Fr::from(1_u32),
+        Fr::from(1_u32),
+        Fr::from(1_u32),
+    ];
 
-    let F_circuit = Sha256FCircuit::<Fr>::new(());
+    let F_circuit = MultipleAddFCircuit::<Fr>::new(());
 
     println!("Prepare Nova ProverParams & VerifierParams");
-    let (prover_params, verifier_params) = nova_setup::<Sha256FCircuit<Fr>>(F_circuit);
+    let (prover_params, verifier_params) = nova_setup::<MultipleAddFCircuit<Fr>>(F_circuit);
 
     /// The idea here is that eventually we could replace the next line chunk that defines the
     /// `type NOVA = Nova<...>` by using another folding scheme that fulfills the `FoldingScheme`
@@ -141,7 +159,7 @@ fn main() {
         GVar,
         Projective2,
         GVar2,
-        Sha256FCircuit<Fr>,
+        MultipleAddFCircuit<Fr>,
         Pedersen<Projective>,
         Pedersen<Projective2>,
     >;
@@ -161,7 +179,7 @@ fn main() {
     println!("Run the Nova's IVC verifier");
     NOVA::verify(
         verifier_params,
-        initial_state,
+        initial_state.clone(),
         folding_scheme.state(), // latest state
         Fr::from(num_steps as u32),
         running_instance,

--- a/folding-schemes/examples/multiple_inputs.rs
+++ b/folding-schemes/examples/multiple_inputs.rs
@@ -14,10 +14,11 @@ use ark_pallas::{constraints::GVar, Fr, Projective};
 use ark_vesta::{constraints::GVar as GVar2, Projective as Projective2};
 
 use folding_schemes::commitment::pedersen::Pedersen;
-use folding_schemes::folding::nova::{get_r1cs, Nova, ProverParams, VerifierParams};
+use folding_schemes::folding::nova::Nova;
 use folding_schemes::frontend::FCircuit;
-use folding_schemes::transcript::poseidon::poseidon_test_config;
 use folding_schemes::{Error, FoldingScheme};
+mod utils;
+use utils::nova_setup;
 
 /// This is the circuit that we want to fold, it implements the FCircuit trait. The parameter z_i
 /// denotes the current state which contains 5 elements, and z_{i+1} denotes the next state which
@@ -69,7 +70,7 @@ impl<F: PrimeField> FCircuit<F> for MultipleAddFCircuit<F> {
     }
 }
 
-/// cargo test --example simple
+/// cargo test --example multiple-inputs
 #[cfg(test)]
 pub mod tests {
     use super::*;
@@ -98,41 +99,6 @@ pub mod tests {
             .unwrap();
         assert_eq!(computed_z_i1Var.value().unwrap(), z_i1);
     }
-}
-
-// This method computes the Prover & Verifier parameters for the example. For a real world use case
-// those parameters should be generated carefuly (both the PoseidonConfig and the PedersenParams)
-#[allow(clippy::type_complexity)]
-fn nova_setup<FC: FCircuit<Fr>>(
-    F_circuit: FC,
-) -> (
-    ProverParams<Projective, Projective2, Pedersen<Projective>, Pedersen<Projective2>>,
-    VerifierParams<Projective, Projective2>,
-) {
-    let mut rng = ark_std::test_rng();
-    let poseidon_config = poseidon_test_config::<Fr>();
-
-    // get the CM & CF_CM len
-    let (r1cs, cf_r1cs) =
-        get_r1cs::<Projective, GVar, Projective2, GVar2, FC>(&poseidon_config, F_circuit).unwrap();
-    let cm_len = r1cs.A.n_rows;
-    let cf_cm_len = cf_r1cs.A.n_rows;
-
-    let pedersen_params = Pedersen::<Projective>::new_params(&mut rng, cm_len);
-    let cf_pedersen_params = Pedersen::<Projective2>::new_params(&mut rng, cf_cm_len);
-
-    let prover_params =
-        ProverParams::<Projective, Projective2, Pedersen<Projective>, Pedersen<Projective2>> {
-            poseidon_config: poseidon_config.clone(),
-            cm_params: pedersen_params,
-            cf_cm_params: cf_pedersen_params,
-        };
-    let verifier_params = VerifierParams::<Projective, Projective2> {
-        poseidon_config: poseidon_config.clone(),
-        r1cs,
-        cf_r1cs,
-    };
-    (prover_params, verifier_params)
 }
 
 /// cargo run --release --example multiple_inputs

--- a/folding-schemes/examples/sha256.rs
+++ b/folding-schemes/examples/sha256.rs
@@ -24,7 +24,7 @@ use folding_schemes::folding::nova::Nova;
 use folding_schemes::frontend::FCircuit;
 use folding_schemes::{Error, FoldingScheme};
 mod utils;
-use utils::nova_setup;
+use utils::test_nova_setup;
 
 /// This is the circuit that we want to fold, it implements the FCircuit trait.
 /// The parameter z_i denotes the current state, and z_{i+1} denotes the next state which we get by
@@ -100,7 +100,7 @@ fn main() {
     let F_circuit = Sha256FCircuit::<Fr>::new(());
 
     println!("Prepare Nova ProverParams & VerifierParams");
-    let (prover_params, verifier_params) = nova_setup::<Sha256FCircuit<Fr>>(F_circuit);
+    let (prover_params, verifier_params) = test_nova_setup::<Sha256FCircuit<Fr>>(F_circuit);
 
     /// The idea here is that eventually we could replace the next line chunk that defines the
     /// `type NOVA = Nova<...>` by using another folding scheme that fulfills the `FoldingScheme`

--- a/folding-schemes/examples/sha256.rs
+++ b/folding-schemes/examples/sha256.rs
@@ -1,0 +1,175 @@
+#![allow(non_snake_case)]
+#![allow(non_upper_case_globals)]
+#![allow(non_camel_case_types)]
+#![allow(clippy::upper_case_acronyms)]
+
+use ark_crypto_primitives::crh::{
+    sha256::{
+        constraints::{Sha256Gadget, UnitVar},
+        Sha256,
+    },
+    CRHScheme, CRHSchemeGadget,
+};
+use ark_ff::{BigInteger, PrimeField, ToConstraintField};
+use ark_r1cs_std::{fields::fp::FpVar, ToBytesGadget, ToConstraintFieldGadget};
+use ark_relations::r1cs::{ConstraintSystemRef, SynthesisError};
+use core::marker::PhantomData;
+use std::time::Instant;
+
+use ark_pallas::{constraints::GVar, Fr, Projective};
+use ark_vesta::{constraints::GVar as GVar2, Projective as Projective2};
+
+use folding_schemes::commitment::pedersen::Pedersen;
+use folding_schemes::folding::nova::{get_r1cs, Nova, ProverParams, VerifierParams};
+use folding_schemes::frontend::FCircuit;
+use folding_schemes::transcript::poseidon::poseidon_test_config;
+use folding_schemes::{Error, FoldingScheme};
+
+/// This is the circuit that we want to fold, it implements the FCircuit trait.
+/// The parameter z_i denotes the current state, and z_{i+1} denotes the next state which we get by
+/// applying the step.
+/// In this example we set z_i and z_{i+1} to be a single value, but the trait is made to support
+/// arrays, so our state could be an array with different values.
+#[derive(Clone, Copy, Debug)]
+pub struct Sha256FCircuit<F: PrimeField> {
+    _f: PhantomData<F>,
+}
+impl<F: PrimeField> FCircuit<F> for Sha256FCircuit<F> {
+    type Params = ();
+
+    fn new(_params: Self::Params) -> Self {
+        Self { _f: PhantomData }
+    }
+    fn state_len(self) -> usize {
+        1
+    }
+
+    /// computes the next state values in place, assigning z_{i+1} into z_i, and computing the new
+    /// z_{i+1}
+    fn step_native(self, z_i: Vec<F>) -> Result<Vec<F>, Error> {
+        let out_bytes = Sha256::evaluate(&(), z_i[0].into_bigint().to_bytes_le()).unwrap();
+        let out: Vec<F> = out_bytes.to_field_elements().unwrap();
+
+        Ok(vec![out[0]])
+    }
+
+    /// generates the constraints for the step of F for the given z_i
+    fn generate_step_constraints(
+        self,
+        _cs: ConstraintSystemRef<F>,
+        z_i: Vec<FpVar<F>>,
+    ) -> Result<Vec<FpVar<F>>, SynthesisError> {
+        let unit_var = UnitVar::default();
+        let out_bytes = Sha256Gadget::evaluate(&unit_var, &z_i[0].to_bytes()?)?;
+        let out = out_bytes.0.to_constraint_field()?;
+        Ok(vec![out[0].clone()])
+    }
+}
+
+/// cargo test --example simple
+#[cfg(test)]
+pub mod tests {
+    use super::*;
+    use ark_r1cs_std::alloc::AllocVar;
+    use ark_relations::r1cs::ConstraintSystem;
+
+    // test to check that the Sha256FCircuit computes the same values inside and outside the circuit
+    #[test]
+    fn test_sha256_f_circuit() {
+        let cs = ConstraintSystem::<Fr>::new_ref();
+
+        let circuit = Sha256FCircuit::<Fr>::new(());
+        let z_i = vec![Fr::from(1_u32)];
+
+        let z_i1 = circuit.step_native(z_i.clone()).unwrap();
+
+        let z_iVar = Vec::<FpVar<Fr>>::new_witness(cs.clone(), || Ok(z_i)).unwrap();
+        let computed_z_i1Var = circuit
+            .generate_step_constraints(cs.clone(), z_iVar.clone())
+            .unwrap();
+        assert_eq!(computed_z_i1Var.value().unwrap(), z_i1);
+    }
+}
+
+// This method computes the Prover & Verifier parameters for the example. For a real world use case
+// those parameters should be generated carefuly (both the PoseidonConfig and the PedersenParams)
+#[allow(clippy::type_complexity)]
+fn nova_setup<FC: FCircuit<Fr>>(
+    F_circuit: FC,
+) -> (
+    ProverParams<Projective, Projective2, Pedersen<Projective>, Pedersen<Projective2>>,
+    VerifierParams<Projective, Projective2>,
+) {
+    let mut rng = ark_std::test_rng();
+    let poseidon_config = poseidon_test_config::<Fr>();
+
+    // get the CM & CF_CM len
+    let (r1cs, cf_r1cs) =
+        get_r1cs::<Projective, GVar, Projective2, GVar2, FC>(&poseidon_config, F_circuit).unwrap();
+    let cm_len = r1cs.A.n_rows;
+    let cf_cm_len = cf_r1cs.A.n_rows;
+
+    let pedersen_params = Pedersen::<Projective>::new_params(&mut rng, cm_len);
+    let cf_pedersen_params = Pedersen::<Projective2>::new_params(&mut rng, cf_cm_len);
+
+    let prover_params =
+        ProverParams::<Projective, Projective2, Pedersen<Projective>, Pedersen<Projective2>> {
+            poseidon_config: poseidon_config.clone(),
+            cm_params: pedersen_params,
+            cf_cm_params: cf_pedersen_params,
+        };
+    let verifier_params = VerifierParams::<Projective, Projective2> {
+        poseidon_config: poseidon_config.clone(),
+        r1cs,
+        cf_r1cs,
+    };
+    (prover_params, verifier_params)
+}
+
+/// cargo run --release --example sha256
+fn main() {
+    let num_steps = 10;
+    let initial_state = vec![Fr::from(1_u32)];
+
+    let F_circuit = Sha256FCircuit::<Fr>::new(());
+
+    println!("Prepare Nova ProverParams & VerifierParams");
+    let (prover_params, verifier_params) = nova_setup::<Sha256FCircuit<Fr>>(F_circuit);
+
+    /// The idea here is that eventually we could replace the next line chunk that defines the
+    /// `type NOVA = Nova<...>` by using another folding scheme that fulfills the `FoldingScheme`
+    /// trait, and the rest of our code would be working without needing to be updated.
+    type NOVA = Nova<
+        Projective,
+        GVar,
+        Projective2,
+        GVar2,
+        Sha256FCircuit<Fr>,
+        Pedersen<Projective>,
+        Pedersen<Projective2>,
+    >;
+
+    println!("Initialize FoldingScheme");
+    let mut folding_scheme = NOVA::init(&prover_params, F_circuit, initial_state.clone()).unwrap();
+
+    // compute a step of the IVC
+    for i in 0..num_steps {
+        let start = Instant::now();
+        folding_scheme.prove_step().unwrap();
+        println!("Nova::prove_step {}: {:?}", i, start.elapsed());
+    }
+
+    let (running_instance, incomming_instance, cyclefold_instance) = folding_scheme.instances();
+
+    println!("Run the Nova's IVC verifier");
+    NOVA::verify(
+        verifier_params,
+        initial_state,
+        folding_scheme.state(), // latest state
+        Fr::from(num_steps as u32),
+        running_instance,
+        incomming_instance,
+        cyclefold_instance,
+    )
+    .unwrap();
+}

--- a/folding-schemes/examples/sha256.rs
+++ b/folding-schemes/examples/sha256.rs
@@ -20,10 +20,11 @@ use ark_pallas::{constraints::GVar, Fr, Projective};
 use ark_vesta::{constraints::GVar as GVar2, Projective as Projective2};
 
 use folding_schemes::commitment::pedersen::Pedersen;
-use folding_schemes::folding::nova::{get_r1cs, Nova, ProverParams, VerifierParams};
+use folding_schemes::folding::nova::Nova;
 use folding_schemes::frontend::FCircuit;
-use folding_schemes::transcript::poseidon::poseidon_test_config;
 use folding_schemes::{Error, FoldingScheme};
+mod utils;
+use utils::nova_setup;
 
 /// This is the circuit that we want to fold, it implements the FCircuit trait.
 /// The parameter z_i denotes the current state, and z_{i+1} denotes the next state which we get by
@@ -66,7 +67,7 @@ impl<F: PrimeField> FCircuit<F> for Sha256FCircuit<F> {
     }
 }
 
-/// cargo test --example simple
+/// cargo test --example sha256
 #[cfg(test)]
 pub mod tests {
     use super::*;
@@ -89,41 +90,6 @@ pub mod tests {
             .unwrap();
         assert_eq!(computed_z_i1Var.value().unwrap(), z_i1);
     }
-}
-
-// This method computes the Prover & Verifier parameters for the example. For a real world use case
-// those parameters should be generated carefuly (both the PoseidonConfig and the PedersenParams)
-#[allow(clippy::type_complexity)]
-fn nova_setup<FC: FCircuit<Fr>>(
-    F_circuit: FC,
-) -> (
-    ProverParams<Projective, Projective2, Pedersen<Projective>, Pedersen<Projective2>>,
-    VerifierParams<Projective, Projective2>,
-) {
-    let mut rng = ark_std::test_rng();
-    let poseidon_config = poseidon_test_config::<Fr>();
-
-    // get the CM & CF_CM len
-    let (r1cs, cf_r1cs) =
-        get_r1cs::<Projective, GVar, Projective2, GVar2, FC>(&poseidon_config, F_circuit).unwrap();
-    let cm_len = r1cs.A.n_rows;
-    let cf_cm_len = cf_r1cs.A.n_rows;
-
-    let pedersen_params = Pedersen::<Projective>::new_params(&mut rng, cm_len);
-    let cf_pedersen_params = Pedersen::<Projective2>::new_params(&mut rng, cf_cm_len);
-
-    let prover_params =
-        ProverParams::<Projective, Projective2, Pedersen<Projective>, Pedersen<Projective2>> {
-            poseidon_config: poseidon_config.clone(),
-            cm_params: pedersen_params,
-            cf_cm_params: cf_pedersen_params,
-        };
-    let verifier_params = VerifierParams::<Projective, Projective2> {
-        poseidon_config: poseidon_config.clone(),
-        r1cs,
-        cf_r1cs,
-    };
-    (prover_params, verifier_params)
 }
 
 /// cargo run --release --example sha256

--- a/folding-schemes/examples/utils.rs
+++ b/folding-schemes/examples/utils.rs
@@ -1,0 +1,48 @@
+#![allow(non_snake_case)]
+#![allow(non_upper_case_globals)]
+#![allow(non_camel_case_types)]
+#![allow(clippy::upper_case_acronyms)]
+#![allow(dead_code)]
+use ark_pallas::{constraints::GVar, Fr, Projective};
+use ark_vesta::{constraints::GVar as GVar2, Projective as Projective2};
+
+use folding_schemes::commitment::pedersen::Pedersen;
+use folding_schemes::folding::nova::{get_r1cs, ProverParams, VerifierParams};
+use folding_schemes::frontend::FCircuit;
+use folding_schemes::transcript::poseidon::poseidon_test_config;
+
+// This method computes the Prover & Verifier parameters for the example. For a real world use case
+// those parameters should be generated carefuly (both the PoseidonConfig and the PedersenParams)
+#[allow(clippy::type_complexity)]
+pub(crate) fn nova_setup<FC: FCircuit<Fr>>(
+    F_circuit: FC,
+) -> (
+    ProverParams<Projective, Projective2, Pedersen<Projective>, Pedersen<Projective2>>,
+    VerifierParams<Projective, Projective2>,
+) {
+    let mut rng = ark_std::test_rng();
+    let poseidon_config = poseidon_test_config::<Fr>();
+
+    // get the CM & CF_CM len
+    let (r1cs, cf_r1cs) =
+        get_r1cs::<Projective, GVar, Projective2, GVar2, FC>(&poseidon_config, F_circuit).unwrap();
+    let cm_len = r1cs.A.n_rows;
+    let cf_cm_len = cf_r1cs.A.n_rows;
+
+    let pedersen_params = Pedersen::<Projective>::new_params(&mut rng, cm_len);
+    let cf_pedersen_params = Pedersen::<Projective2>::new_params(&mut rng, cf_cm_len);
+
+    let prover_params =
+        ProverParams::<Projective, Projective2, Pedersen<Projective>, Pedersen<Projective2>> {
+            poseidon_config: poseidon_config.clone(),
+            cm_params: pedersen_params,
+            cf_cm_params: cf_pedersen_params,
+        };
+    let verifier_params = VerifierParams::<Projective, Projective2> {
+        poseidon_config: poseidon_config.clone(),
+        r1cs,
+        cf_r1cs,
+    };
+    (prover_params, verifier_params)
+}
+fn main() {}

--- a/folding-schemes/examples/utils.rs
+++ b/folding-schemes/examples/utils.rs
@@ -15,7 +15,7 @@ use folding_schemes::transcript::poseidon::poseidon_test_config;
 // Warning: this method is only for testing purposes. For a real world use case those parameters
 // should be generated carefuly (both the PoseidonConfig and the PedersenParams).
 #[allow(clippy::type_complexity)]
-pub(crate) fn nova_setup<FC: FCircuit<Fr>>(
+pub(crate) fn test_nova_setup<FC: FCircuit<Fr>>(
     F_circuit: FC,
 ) -> (
     ProverParams<Projective, Projective2, Pedersen<Projective>, Pedersen<Projective2>>,

--- a/folding-schemes/examples/utils.rs
+++ b/folding-schemes/examples/utils.rs
@@ -11,8 +11,9 @@ use folding_schemes::folding::nova::{get_r1cs, ProverParams, VerifierParams};
 use folding_schemes::frontend::FCircuit;
 use folding_schemes::transcript::poseidon::poseidon_test_config;
 
-// This method computes the Prover & Verifier parameters for the example. For a real world use case
-// those parameters should be generated carefuly (both the PoseidonConfig and the PedersenParams)
+// This method computes the Prover & Verifier parameters for the example.
+// Warning: this method is only for testing purposes. For a real world use case those parameters
+// should be generated carefuly (both the PoseidonConfig and the PedersenParams).
 #[allow(clippy::type_complexity)]
 pub(crate) fn nova_setup<FC: FCircuit<Fr>>(
     F_circuit: FC,

--- a/folding-schemes/src/folding/nova/circuits.rs
+++ b/folding-schemes/src/folding/nova/circuits.rs
@@ -310,10 +310,14 @@ where
             Ok(self.i.unwrap_or_else(CF1::<C1>::zero))
         })?;
         let z_0 = Vec::<FpVar<CF1<C1>>>::new_witness(cs.clone(), || {
-            Ok(self.z_0.unwrap_or(vec![CF1::<C1>::zero()]))
+            Ok(self
+                .z_0
+                .unwrap_or(vec![CF1::<C1>::zero(); self.F.state_len()]))
         })?;
         let z_i = Vec::<FpVar<CF1<C1>>>::new_witness(cs.clone(), || {
-            Ok(self.z_i.unwrap_or(vec![CF1::<C1>::zero()]))
+            Ok(self
+                .z_i
+                .unwrap_or(vec![CF1::<C1>::zero(); self.F.state_len()]))
         })?;
 
         let u_dummy_native = CommittedInstance::<C1>::dummy(1);

--- a/folding-schemes/src/frontend/mod.rs
+++ b/folding-schemes/src/frontend/mod.rs
@@ -16,7 +16,8 @@ pub trait FCircuit<F: PrimeField>: Clone + Copy + Debug {
     /// returns a new FCircuit instance
     fn new(params: Self::Params) -> Self;
 
-    /// returns the number of elements in the state of the FCircuit
+    /// returns the number of elements in the state of the FCircuit, which corresponds to the
+    /// FCircuit inputs.
     fn state_len(self) -> usize;
 
     /// computes the next state values in place, assigning z_{i+1} into z_i, and computing the new

--- a/folding-schemes/src/frontend/mod.rs
+++ b/folding-schemes/src/frontend/mod.rs
@@ -16,6 +16,9 @@ pub trait FCircuit<F: PrimeField>: Clone + Copy + Debug {
     /// returns a new FCircuit instance
     fn new(params: Self::Params) -> Self;
 
+    /// returns the number of elements in the state of the FCircuit
+    fn state_len(self) -> usize;
+
     /// computes the next state values in place, assigning z_{i+1} into z_i, and computing the new
     /// z_{i+1}
     fn step_native(
@@ -59,6 +62,9 @@ pub mod tests {
         fn new(_params: Self::Params) -> Self {
             Self { _f: PhantomData }
         }
+        fn state_len(self) -> usize {
+            1
+        }
         fn step_native(self, z_i: Vec<F>) -> Result<Vec<F>, Error> {
             Ok(vec![z_i[0] * z_i[0] * z_i[0] + z_i[0] + F::from(5_u32)])
         }
@@ -89,6 +95,9 @@ pub mod tests {
                 _f: PhantomData,
                 n_constraints: params,
             }
+        }
+        fn state_len(self) -> usize {
+            1
         }
         fn step_native(self, z_i: Vec<F>) -> Result<Vec<F>, Error> {
             let mut z_i1 = F::one();


### PR DESCRIPTION
@dmpierre found out that when using the multiple-elements state option for folding Nova it crashes. Turns out that in the AugmentedFCircuit the default value for the state when no input is provided was `vec![F::zero()]`, which defaults to length `1`. So when having more than 1 element in the state, before even starting to fold, just when creating the circuit, it already fails.

This PR fixes that, so now folding a state that has multiple elements works.

Also this PR adds an example for a circuit with a state of 5 elements.