### PR TITLE
Add typos tool to CI to automate typo detection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,3 +102,13 @@ jobs:
         with:
           command: clippy
           args: --all-targets --all-features -- -D warnings
+
+  typos:
+    name: Spell Check with Typos
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Use typos with config file
+      uses: crate-ci/typos@master
+      with: 
+        config: .github/workflows/typos.toml

--- a/.github/workflows/typos.toml
+++ b/.github/workflows/typos.toml
@@ -1,6 +1,2 @@
-[default]
-extend-ignore-identifiers-re = [
-]
-
 [default.extend-words]
 groth = "groth"

--- a/.github/workflows/typos.toml
+++ b/.github/workflows/typos.toml
@@ -1,0 +1,7 @@
+[default]
+extend-ignore-identifiers-re = [
+]
+
+[default.extend-words]
+# Don't correct the surname "Teh"
+groth = "groth"

--- a/.github/workflows/typos.toml
+++ b/.github/workflows/typos.toml
@@ -3,5 +3,4 @@ extend-ignore-identifiers-re = [
 ]
 
 [default.extend-words]
-# Don't correct the surname "Teh"
 groth = "groth"

--- a/folding-schemes-solidity/templates/kzg10_verifier.askama.sol
+++ b/folding-schemes-solidity/templates/kzg10_verifier.askama.sol
@@ -231,7 +231,7 @@ contract KZG10Verifier {
             require(eval_z == 0, "checkAndCommitAuxPolys: wrong zero poly");
             require(eval_l == y_vals[i], "checkAndCommitAuxPolys: wrong lagrange poly");
         }
-        // z(x) has len(x_vals) + 1 coeffs, we add to the commmitment the last coeff of z(x)
+        // z(x) has len(x_vals) + 1 coeffs, we add to the commitment the last coeff of z(x)
         z_commit = add(z_commit, mulScalar(G1_CRS[z_coeffs.length - 1], z_coeffs[z_coeffs.length - 1]));
 
         return (z_commit, l_commit);

--- a/folding-schemes/examples/multi_inputs.rs
+++ b/folding-schemes/examples/multi_inputs.rs
@@ -58,12 +58,12 @@ impl<F: PrimeField> FCircuit<F> for MultiInputsFCircuit<F> {
         z_i: Vec<FpVar<F>>,
     ) -> Result<Vec<FpVar<F>>, SynthesisError> {
         let four = FpVar::<F>::new_constant(cs.clone(), F::from(4u32))?;
-        let fourty = FpVar::<F>::new_constant(cs.clone(), F::from(40u32))?;
+        let forty = FpVar::<F>::new_constant(cs.clone(), F::from(40u32))?;
         let onehundred = FpVar::<F>::new_constant(cs.clone(), F::from(100u32))?;
         let a = z_i[0].clone() + four.clone();
-        let b = z_i[1].clone() + fourty.clone();
+        let b = z_i[1].clone() + forty.clone();
         let c = z_i[2].clone() * four;
-        let d = z_i[3].clone() * fourty;
+        let d = z_i[3].clone() * forty;
         let e = z_i[4].clone() + onehundred;
 
         Ok(vec![a, b, c, d, e])
@@ -140,7 +140,7 @@ fn main() {
         println!("Nova::prove_step {}: {:?}", i, start.elapsed());
     }
 
-    let (running_instance, incomming_instance, cyclefold_instance) = folding_scheme.instances();
+    let (running_instance, incoming_instance, cyclefold_instance) = folding_scheme.instances();
 
     println!("Run the Nova's IVC verifier");
     NOVA::verify(
@@ -149,7 +149,7 @@ fn main() {
         folding_scheme.state(), // latest state
         Fr::from(num_steps as u32),
         running_instance,
-        incomming_instance,
+        incoming_instance,
         cyclefold_instance,
     )
     .unwrap();

--- a/folding-schemes/examples/sha256.rs
+++ b/folding-schemes/examples/sha256.rs
@@ -125,7 +125,7 @@ fn main() {
         println!("Nova::prove_step {}: {:?}", i, start.elapsed());
     }
 
-    let (running_instance, incomming_instance, cyclefold_instance) = folding_scheme.instances();
+    let (running_instance, incoming_instance, cyclefold_instance) = folding_scheme.instances();
 
     println!("Run the Nova's IVC verifier");
     NOVA::verify(
@@ -134,7 +134,7 @@ fn main() {
         folding_scheme.state(), // latest state
         Fr::from(num_steps as u32),
         running_instance,
-        incomming_instance,
+        incoming_instance,
         cyclefold_instance,
     )
     .unwrap();

--- a/folding-schemes/examples/utils.rs
+++ b/folding-schemes/examples/utils.rs
@@ -13,7 +13,7 @@ use folding_schemes::transcript::poseidon::poseidon_test_config;
 
 // This method computes the Prover & Verifier parameters for the example.
 // Warning: this method is only for testing purposes. For a real world use case those parameters
-// should be generated carefuly (both the PoseidonConfig and the PedersenParams).
+// should be generated carefully (both the PoseidonConfig and the PedersenParams).
 #[allow(clippy::type_complexity)]
 pub(crate) fn test_nova_setup<FC: FCircuit<Fr>>(
     F_circuit: FC,

--- a/folding-schemes/src/ccs/r1cs.rs
+++ b/folding-schemes/src/ccs/r1cs.rs
@@ -97,7 +97,7 @@ pub fn extract_r1cs<F: PrimeField>(cs: &ConstraintSystem<F>) -> R1CS<F> {
     };
 
     R1CS::<F> {
-        l: cs.num_instance_variables - 1, // -1 to substract the first '1'
+        l: cs.num_instance_variables - 1, // -1 to subtract the first '1'
         A,
         B,
         C,

--- a/folding-schemes/src/commitment/kzg.rs
+++ b/folding-schemes/src/commitment/kzg.rs
@@ -80,7 +80,7 @@ where
 
     /// commit implements the CommitmentProver commit interface, adapting the implementation from
     /// https://github.com/arkworks-rs/poly-commit/tree/c724fa666e935bbba8db5a1421603bab542e15ab/poly-commit/src/kzg10/mod.rs#L178
-    /// with the main difference being the removal of the blinding factors and the no-dependancy to
+    /// with the main difference being the removal of the blinding factors and the no-dependency to
     /// the Pairing trait.
     fn commit(
         params: &Self::Params,
@@ -105,7 +105,7 @@ where
 
     /// prove implements the CommitmentProver prove interface, adapting the implementation from
     /// https://github.com/arkworks-rs/poly-commit/tree/c724fa666e935bbba8db5a1421603bab542e15ab/poly-commit/src/kzg10/mod.rs#L307
-    /// with the main difference being the removal of the blinding factors and the no-dependancy to
+    /// with the main difference being the removal of the blinding factors and the no-dependency to
     /// the Pairing trait.
     fn prove(
         params: &Self::Params,

--- a/folding-schemes/src/folding/circuits/nonnative.rs
+++ b/folding-schemes/src/folding/circuits/nonnative.rs
@@ -10,7 +10,7 @@ use ark_relations::r1cs::{Namespace, SynthesisError};
 use ark_std::{One, Zero};
 use core::borrow::Borrow;
 
-/// NonNativeAffineVar represents an elliptic curve point in Affine represenation in the non-native
+/// NonNativeAffineVar represents an elliptic curve point in Affine representation in the non-native
 /// field, over the constraint field. It is not intended to perform operations, but just to contain
 /// the affine coordinates in order to perform hash operations of the point.
 #[derive(Debug, Clone)]

--- a/folding-schemes/src/folding/hypernova/cccs.rs
+++ b/folding-schemes/src/folding/hypernova/cccs.rs
@@ -111,7 +111,7 @@ impl<C: CurveGroup> CCCS<C> {
         w: &Witness<C::ScalarField>,
     ) -> Result<(), Error> {
         // check that C is the commitment of w. Notice that this is not verifying a Pedersen
-        // opening, but checking that the Commmitment comes from committing to the witness.
+        // opening, but checking that the commitment comes from committing to the witness.
         if self.C != Pedersen::commit(pedersen_params, &w.w, &w.r_w)? {
             return Err(Error::NotSatisfied);
         }

--- a/folding-schemes/src/folding/hypernova/lcccs.rs
+++ b/folding-schemes/src/folding/hypernova/lcccs.rs
@@ -133,7 +133,7 @@ pub mod tests {
 
         let pedersen_params = Pedersen::<Projective>::new_params(&mut rng, ccs.n - ccs.l - 1);
         let (lcccs, _) = ccs.to_lcccs(&mut rng, &pedersen_params, &z).unwrap();
-        // with our test vector comming from R1CS, v should have length 3
+        // with our test vector coming from R1CS, v should have length 3
         assert_eq!(lcccs.v.len(), 3);
 
         let vec_L_j_x = lcccs.compute_Ls(&ccs, &z);
@@ -164,7 +164,7 @@ pub mod tests {
         let pedersen_params = Pedersen::<Projective>::new_params(&mut rng, ccs.n - ccs.l - 1);
         // Compute v_j with the right z
         let (lcccs, _) = ccs.to_lcccs(&mut rng, &pedersen_params, &z).unwrap();
-        // with our test vector comming from R1CS, v should have length 3
+        // with our test vector coming from R1CS, v should have length 3
         assert_eq!(lcccs.v.len(), 3);
 
         // Bad compute L_j(x) with the bad z

--- a/folding-schemes/src/folding/hypernova/lcccs.rs
+++ b/folding-schemes/src/folding/hypernova/lcccs.rs
@@ -96,7 +96,7 @@ impl<C: CurveGroup> LCCCS<C> {
         w: &Witness<C::ScalarField>,
     ) -> Result<(), Error> {
         // check that C is the commitment of w. Notice that this is not verifying a Pedersen
-        // opening, but checking that the Commmitment comes from committing to the witness.
+        // opening, but checking that the commitment comes from committing to the witness.
         if self.C != Pedersen::commit(pedersen_params, &w.w, &w.r_w)? {
             return Err(Error::NotSatisfied);
         }

--- a/folding-schemes/src/folding/nova/circuits.rs
+++ b/folding-schemes/src/folding/nova/circuits.rs
@@ -445,7 +445,7 @@ where
         (cf_u_i.cmE.is_zero()?).conditional_enforce_equal(&Boolean::TRUE, &is_not_basecase)?;
         (cf_u_i.u.is_one()?).conditional_enforce_equal(&Boolean::TRUE, &is_not_basecase)?;
 
-        // check the fold of all the parameteres of the CycleFold instances, where the elliptic
+        // check the fold of all the parameters of the CycleFold instances, where the elliptic
         // curve points relations are checked natively in Curve1 circuit (this one)
         let v = NIFSFullGadget::<C2, GC2>::verify(
             cf_r_bits,

--- a/folding-schemes/src/folding/nova/circuits.rs
+++ b/folding-schemes/src/folding/nova/circuits.rs
@@ -572,7 +572,7 @@ pub mod tests {
         assert_eq!(hVar.value().unwrap(), h);
     }
 
-    // checks that the gadget and native implementations of the challenge computation matcbh
+    // checks that the gadget and native implementations of the challenge computation match
     #[test]
     fn test_challenge_gadget() {
         let mut rng = ark_std::test_rng();

--- a/folding-schemes/src/folding/nova/decider_eth.rs
+++ b/folding-schemes/src/folding/nova/decider_eth.rs
@@ -50,7 +50,7 @@ where
     <C2 as Group>::ScalarField: Absorb,
     C1: CurveGroup<BaseField = C2::ScalarField, ScalarField = C2::BaseField>,
     for<'b> &'b GC2: GroupOpsBounds<'b, C2, GC2>,
-    // constrain FS into Nova, since this is a Decider specificly for Nova
+    // constrain FS into Nova, since this is a Decider specifically for Nova
     Nova<C1, GC1, C2, GC2, FC, CP1, CP2>: From<FS>,
 {
     type ProverParam = S::ProvingKey;

--- a/folding-schemes/src/folding/nova/mod.rs
+++ b/folding-schemes/src/folding/nova/mod.rs
@@ -491,11 +491,11 @@ where
         z_i: Vec<C1::ScalarField>, // last state
         num_steps: C1::ScalarField,
         running_instance: Self::CommittedInstanceWithWitness,
-        incomming_instance: Self::CommittedInstanceWithWitness,
+        incoming_instance: Self::CommittedInstanceWithWitness,
         cyclefold_instance: Self::CFCommittedInstanceWithWitness,
     ) -> Result<(), Error> {
         let (U_i, W_i) = running_instance;
-        let (u_i, w_i) = incomming_instance;
+        let (u_i, w_i) = incoming_instance;
         let (cf_U_i, cf_W_i) = cyclefold_instance;
 
         if u_i.x.len() != 1 || U_i.x.len() != 1 {

--- a/folding-schemes/src/folding/nova/nifs.rs
+++ b/folding-schemes/src/folding/nova/nifs.rs
@@ -161,7 +161,7 @@ where
         NIFS::<C, CP>::fold_committed_instance(r, ci1, ci2, cmT)
     }
 
-    /// Verify commited folded instance (ci) relations. Notice that this method does not open the
+    /// Verify committed folded instance (ci) relations. Notice that this method does not open the
     /// commitments, but just checks that the given committed instances (ci1, ci2) when folded
     /// result in the folded committed instance (ci3) values.
     pub fn verify_folded_instance(
@@ -426,16 +426,16 @@ pub mod tests {
 
         let num_iters = 10;
         for i in 0..num_iters {
-            // prepare the incomming instance
-            let incomming_instance_z = get_test_z(i + 4);
-            let (w, x) = r1cs.split_z(&incomming_instance_z);
-            let incomming_instance_w = Witness::<Projective>::new(w.clone(), r1cs.A.n_rows);
-            let incomming_committed_instance = incomming_instance_w
+            // prepare the incoming instance
+            let incoming_instance_z = get_test_z(i + 4);
+            let (w, x) = r1cs.split_z(&incoming_instance_z);
+            let incoming_instance_w = Witness::<Projective>::new(w.clone(), r1cs.A.n_rows);
+            let incoming_committed_instance = incoming_instance_w
                 .commit::<Pedersen<Projective>>(&pedersen_params, x)
                 .unwrap();
             r1cs.check_relaxed_instance_relation(
-                &incomming_instance_w,
-                &incomming_committed_instance,
+                &incoming_instance_w,
+                &incoming_committed_instance,
             )
             .unwrap();
 
@@ -447,16 +447,16 @@ pub mod tests {
                 &r1cs,
                 &running_instance_w,
                 &running_committed_instance,
-                &incomming_instance_w,
-                &incomming_committed_instance,
+                &incoming_instance_w,
+                &incoming_committed_instance,
             )
             .unwrap();
             let (folded_w, _) = NIFS::<Projective, Pedersen<Projective>>::fold_instances(
                 r,
                 &running_instance_w,
                 &running_committed_instance,
-                &incomming_instance_w,
-                &incomming_committed_instance,
+                &incoming_instance_w,
+                &incoming_committed_instance,
                 &T,
                 cmT,
             )
@@ -466,7 +466,7 @@ pub mod tests {
             let folded_committed_instance = NIFS::<Projective, Pedersen<Projective>>::verify(
                 r,
                 &running_committed_instance,
-                &incomming_committed_instance,
+                &incoming_committed_instance,
                 &cmT,
             );
 

--- a/folding-schemes/src/folding/nova/nifs.rs
+++ b/folding-schemes/src/folding/nova/nifs.rs
@@ -143,7 +143,7 @@ where
         // use r_T=1 since we don't need hiding property for cm(T)
         let w3 = NIFS::<C, CP>::fold_witness(r, w1, w2, T, C::ScalarField::one())?;
 
-        // fold committed instancs
+        // fold committed instances
         let ci3 = NIFS::<C, CP>::fold_committed_instance(r, ci1, ci2, &cmT);
 
         Ok((w3, ci3))

--- a/folding-schemes/src/folding/protogalaxy/folding.rs
+++ b/folding-schemes/src/folding/protogalaxy/folding.rs
@@ -522,7 +522,7 @@ mod tests {
         )
         .unwrap();
 
-        // veriier
+        // verifier
         let folded_instance_v = Folding::<Projective>::verify(
             &mut transcript_v,
             &r1cs,
@@ -572,7 +572,7 @@ mod tests {
                 )
                 .unwrap();
 
-            // veriier
+            // verifier
             let folded_instance_v = Folding::<Projective>::verify(
                 &mut transcript_v,
                 &r1cs,

--- a/folding-schemes/src/folding/protogalaxy/folding.rs
+++ b/folding-schemes/src/folding/protogalaxy/folding.rs
@@ -40,7 +40,7 @@ where
         // running instance
         instance: &CommittedInstance<C>,
         w: &Witness<C::ScalarField>,
-        // incomming instances
+        // incoming instances
         vec_instances: &[CommittedInstance<C>],
         vec_w: &[Witness<C::ScalarField>],
     ) -> Result<
@@ -226,7 +226,7 @@ where
         r1cs: &R1CS<C::ScalarField>,
         // running instance
         instance: &CommittedInstance<C>,
-        // incomming instances
+        // incoming instances
         vec_instances: &[CommittedInstance<C>],
         // polys from P
         F_coeffs: Vec<C::ScalarField>,
@@ -440,7 +440,7 @@ mod tests {
         assert!(!is_zero_vec(&f_w));
     }
 
-    // k represents the number of instances to be fold, appart from the running instance
+    // k represents the number of instances to be fold, apart from the running instance
     #[allow(clippy::type_complexity)]
     fn prepare_inputs(
         k: usize,

--- a/folding-schemes/src/lib.rs
+++ b/folding-schemes/src/lib.rs
@@ -42,7 +42,7 @@ pub enum Error {
     NotExpectedLength(usize, usize),
     #[error("Can not be empty")]
     Empty,
-    #[error("Pedersen parameters length is not suficient (generators.len={0} < vector.len={1} unsatisfied)")]
+    #[error("Pedersen parameters length is not sufficient (generators.len={0} < vector.len={1} unsatisfied)")]
     PedersenParamsLen(usize, usize),
     #[error("Commitment verification failed")]
     CommitmentVerificationFail,
@@ -116,7 +116,7 @@ where
         // number of steps between the initial state and the last state
         num_steps: C1::ScalarField,
         running_instance: Self::CommittedInstanceWithWitness,
-        incomming_instance: Self::CommittedInstanceWithWitness,
+        incoming_instance: Self::CommittedInstanceWithWitness,
         cyclefold_instance: Self::CFCommittedInstanceWithWitness,
     ) -> Result<(), Error>;
 }

--- a/folding-schemes/src/transcript/poseidon.rs
+++ b/folding-schemes/src/transcript/poseidon.rs
@@ -57,7 +57,7 @@ where
     }
 }
 
-// Returns the point coordinates in Fr, so it can be absrobed by the transcript. It does not work
+// Returns the point coordinates in Fr, so it can be absorbed by the transcript. It does not work
 // over bytes in order to have a logic that can be reproduced in-circuit.
 fn prepare_point<C: CurveGroup>(p: &C) -> Result<Vec<C::ScalarField>, Error> {
     let affine = p.into_affine();


### PR DESCRIPTION
**Motivation:**
Since recently more projects are starting to do airdrops and using lists of repositories to reward contributors (eg. Namada, StarkWare, etc), a new wave of airdrop farmers has emerged, no longer collecting discord chat points but now going after code contributions.
*In the era of bots and automation, we must protect humans attention and time*, and in this case we can avoid spending time on airdrop-farmers PRs that could simply be avoided by having our own automated tool.

This has been already a problem to other projects, we were postponing it but seems that we are now target too: https://github.com/privacy-scaling-explorations/folding-schemes/pull/75

A quick look at the PR author profile shows some other PRs from the same user executing a typo-finding-tool and opening PRs (listing here only few):
https://github.com/privacy-scaling-explorations/snark-verifier/pull/60
https://github.com/privacy-scaling-explorations/chiquito/pull/210
https://github.com/privacy-scaling-explorations/zk-kit/pull/182
https://github.com/privacy-scaling-explorations/halo2curves/pull/140
https://github.com/privacy-scaling-explorations/p0tion/pull/266
https://github.com/privacy-scaling-explorations/maci/pull/1245
https://github.com/privacy-scaling-explorations/zkevm-circuits/pull/1780
https://github.com/privacy-scaling-explorations/bandada/pull/409
https://github.com/ethereum/solidity/pull/14815
https://github.com/netdata/netdata/pull/17049
https://github.com/ethereum/c-kzg-4844/pull/397
https://github.com/ethereum/hevm/pull/458
https://github.com/aptos-labs/aptos-ts-sdk/pull/300 (Notice that in this case, the reviewers asked a small change and the PR-farmer decided [*it was not worth the effort*](https://github.com/aptos-labs/aptos-ts-sdk/pull/300#issuecomment-1957186217))
https://github.com/aptos-labs/aptos-networks/pull/61
https://github.com/nimiq/core-rs-albatross/pull/2241


There are now even twitter tutorials on how to farm contributions: https://twitter.com/Abrahamchase09/status/1759101213381959960 , which has their results: https://twitter.com/toghrulmaharram/status/1759228275228905511 .


A solution could be from time to time do a PR fixing all typos, as done here: https://github.com/risc0/risc0/pull/1319 , but this does not prevent future typos from happening.

**What this PR does:**
Add GitHub CI that runs [typos](https://github.com/crate-ci/typos) so future PRs will run the `typos` check to detect typos. Also this PR fixes the detected typos.

**About the tool:**
- Tried [cspell](https://github.com/streetsidesoftware/cspell) (typescript) , and it has too many false-positives (thousands) for custom variable names that we don't consider them typos (eg. `Multilinear, evals, arkworks, thiserror, Circom, biguint, nbits, ...` and a thousand more), since it works with a dictionary of correct words approach.
- Then with [typos](https://github.com/crate-ci/typos) (rust), since it does not work with a dictionary of correct words but with a dictionary of typos corrections, it does not have the false positives that *cspell* has. The downside of this approach is that it might not recognize typos that are not yet in their list, but it can [easily be updated](https://github.com/crate-ci/typos/blob/master/CONTRIBUTING.md#updating-the-dictionary).