### PR TITLE
Change CycleFold circuit approach

### DIFF
--- a/folding-schemes/src/folding/nova/circuits.rs
+++ b/folding-schemes/src/folding/nova/circuits.rs
@@ -475,7 +475,7 @@ where
         (cf2_u_i.cmE.is_zero()?).conditional_enforce_equal(&Boolean::TRUE, &is_not_basecase)?;
         (cf2_u_i.u.is_one()?).conditional_enforce_equal(&Boolean::TRUE, &is_not_basecase)?;
 
-        // check the fold of all the parameteres of the CycleFold instances, where the elliptic
+        // check the fold of all the parameters of the CycleFold instances, where the elliptic
         // curve points relations are checked natively in Curve1 circuit (this one)
         let v1 = NIFSFullGadget::<C2, GC2>::verify(
             cf1_r_bits,

--- a/folding-schemes/src/folding/nova/cyclefold.rs
+++ b/folding-schemes/src/folding/nova/cyclefold.rs
@@ -27,8 +27,8 @@ use super::CommittedInstance;
 use crate::constants::N_BITS_RO;
 use crate::Error;
 
-// publi inputs length for the CycleFoldCircuit, |[u_i, U_i, U_{i+1}]|
-pub const CF_IO_LEN: usize = 12;
+// publi inputs length for the CycleFoldCircuit, |[p1.x,y, p2.x,y, p3.x,y]|
+pub const CF_IO_LEN: usize = 6;
 
 /// CycleFoldCommittedInstanceVar is the CycleFold CommittedInstance representation in the Nova
 /// circuit.
@@ -122,6 +122,7 @@ where
     }
 }
 
+/*
 /// NIFSinCycleFoldGadget performs the Nova NIFS.V elliptic curve points relation checks in the other
 /// curve (natively) following [CycleFold](https://eprint.iacr.org/2023/1192.pdf).
 pub struct NIFSinCycleFoldGadget<C: CurveGroup, GC: CurveVar<C, CF2<C>>> {
@@ -155,6 +156,7 @@ where
         first_check.and(&second_check)
     }
 }
+*/
 
 /// This is the gadget used in the AugmentedFCircuit to verify the CycleFold instances folding,
 /// which checks the correct RLC of u,x,cmE,cmW (hence the name containing 'Full', since it checks
@@ -224,38 +226,38 @@ where
 {
     pub fn get_challenge_native(
         poseidon_config: &PoseidonConfig<C::BaseField>,
-        u_i: CommittedInstance<C>,
         U_i: CommittedInstance<C>,
+        u_i: CommittedInstance<C>,
         cmT: C,
     ) -> Result<Vec<bool>, Error> {
         let mut sponge = PoseidonSponge::<C::BaseField>::new(poseidon_config);
 
-        let u_i_cmE_bytes = point_to_bytes(u_i.cmE);
-        let u_i_cmW_bytes = point_to_bytes(u_i.cmW);
         let U_i_cmE_bytes = point_to_bytes(U_i.cmE);
         let U_i_cmW_bytes = point_to_bytes(U_i.cmW);
+        let u_i_cmE_bytes = point_to_bytes(u_i.cmE);
+        let u_i_cmW_bytes = point_to_bytes(u_i.cmW);
         let cmT_bytes = point_to_bytes(cmT);
 
-        let mut u_i_u_bytes = Vec::new();
-        u_i.u.serialize_uncompressed(&mut u_i_u_bytes)?;
-        let mut u_i_x_bytes = Vec::new();
-        u_i.x.serialize_uncompressed(&mut u_i_x_bytes)?;
-        u_i_x_bytes = u_i_x_bytes[8..].to_vec();
         let mut U_i_u_bytes = Vec::new();
         U_i.u.serialize_uncompressed(&mut U_i_u_bytes)?;
         let mut U_i_x_bytes = Vec::new();
         U_i.x.serialize_uncompressed(&mut U_i_x_bytes)?;
         U_i_x_bytes = U_i_x_bytes[8..].to_vec();
+        let mut u_i_u_bytes = Vec::new();
+        u_i.u.serialize_uncompressed(&mut u_i_u_bytes)?;
+        let mut u_i_x_bytes = Vec::new();
+        u_i.x.serialize_uncompressed(&mut u_i_x_bytes)?;
+        u_i_x_bytes = u_i_x_bytes[8..].to_vec();
 
         let input: Vec<u8> = [
-            u_i_cmE_bytes,
-            u_i_u_bytes,
-            u_i_cmW_bytes,
-            u_i_x_bytes,
             U_i_cmE_bytes,
             U_i_u_bytes,
             U_i_cmW_bytes,
             U_i_x_bytes,
+            u_i_cmE_bytes,
+            u_i_u_bytes,
+            u_i_cmW_bytes,
+            u_i_x_bytes,
             cmT_bytes,
         ]
         .concat();
@@ -267,32 +269,32 @@ where
     pub fn get_challenge_gadget(
         cs: ConstraintSystemRef<C::BaseField>,
         poseidon_config: &PoseidonConfig<C::BaseField>,
-        u_i: CycleFoldCommittedInstanceVar<C, GC>,
         U_i: CycleFoldCommittedInstanceVar<C, GC>,
+        u_i: CycleFoldCommittedInstanceVar<C, GC>,
         cmT: GC,
     ) -> Result<Vec<Boolean<C::BaseField>>, SynthesisError> {
         let mut sponge = PoseidonSpongeVar::<C::BaseField>::new(cs, poseidon_config);
 
-        let u_i_x_bytes: Vec<UInt8<CF2<C>>> = u_i
+        let U_i_x_bytes: Vec<UInt8<CF2<C>>> = U_i
             .x
             .iter()
             .flat_map(|e| e.to_bytes().unwrap_or(vec![]))
             .collect::<Vec<UInt8<CF2<C>>>>();
-        let U_i_x_bytes: Vec<UInt8<CF2<C>>> = U_i
+        let u_i_x_bytes: Vec<UInt8<CF2<C>>> = u_i
             .x
             .iter()
             .flat_map(|e| e.to_bytes().unwrap_or(vec![]))
             .collect::<Vec<UInt8<CF2<C>>>>();
 
         let input: Vec<UInt8<CF2<C>>> = [
-            u_i.cmE.to_bytes()?,
-            u_i.u.to_bytes()?,
-            u_i.cmW.to_bytes()?,
-            u_i_x_bytes,
             U_i.cmE.to_bytes()?,
             U_i.u.to_bytes()?,
             U_i.cmW.to_bytes()?,
             U_i_x_bytes,
+            u_i.cmE.to_bytes()?,
+            u_i.u.to_bytes()?,
+            u_i.cmW.to_bytes()?,
+            u_i_x_bytes,
             cmT.to_bytes()?,
             // TODO instead of bytes, use field elements, but needs x,y coordinates from
             // u_i.{cmE,cmW}, U_i.{cmE,cmW}, cmT. Depends exposing x,y coordinates of GC. Issue to
@@ -326,12 +328,9 @@ fn point_to_bytes<C: CurveGroup>(p: C) -> Vec<u8> {
 pub struct CycleFoldCircuit<C: CurveGroup, GC: CurveVar<C, CF2<C>>> {
     pub _gc: PhantomData<GC>,
     pub r_bits: Option<Vec<bool>>,
-    pub cmT: Option<C>,
-    // u_i,U_i,U_i1 are the nova instances from AugmentedFCircuit which will be (their elliptic
-    // curve points) checked natively in CycleFoldCircuit
-    pub u_i: Option<CommittedInstance<C>>,
-    pub U_i: Option<CommittedInstance<C>>,
-    pub U_i1: Option<CommittedInstance<C>>,
+    pub p1: Option<C>,
+    pub p2: Option<C>,
+    pub p3: Option<C>,
     pub x: Option<Vec<CF2<C>>>, // public inputs (cf_u_{i+1}.x)
 }
 impl<C: CurveGroup, GC: CurveVar<C, CF2<C>>> CycleFoldCircuit<C, GC> {
@@ -339,10 +338,9 @@ impl<C: CurveGroup, GC: CurveVar<C, CF2<C>>> CycleFoldCircuit<C, GC> {
         Self {
             _gc: PhantomData,
             r_bits: None,
-            cmT: None,
-            u_i: None,
-            U_i: None,
-            U_i1: None,
+            p1: None,
+            p2: None,
+            p3: None,
             x: None,
         }
     }
@@ -358,29 +356,21 @@ where
         let r_bits: Vec<Boolean<CF2<C>>> = Vec::new_witness(cs.clone(), || {
             Ok(self.r_bits.unwrap_or(vec![false; N_BITS_RO]))
         })?;
-        let cmT = GC::new_witness(cs.clone(), || Ok(self.cmT.unwrap_or(C::zero())))?;
+        let p1 = GC::new_witness(cs.clone(), || Ok(self.p1.unwrap_or(C::zero())))?;
+        let p2 = GC::new_witness(cs.clone(), || Ok(self.p2.unwrap_or(C::zero())))?;
+        let p3 = GC::new_witness(cs.clone(), || Ok(self.p3.unwrap_or(C::zero())))?;
 
-        let u_dummy_native = CommittedInstance::<C>::dummy(1);
-
-        let u_i = CommittedInstanceInCycleFoldVar::<C, GC>::new_witness(cs.clone(), || {
-            Ok(self.u_i.unwrap_or(u_dummy_native.clone()))
-        })?;
-        let U_i = CommittedInstanceInCycleFoldVar::<C, GC>::new_witness(cs.clone(), || {
-            Ok(self.U_i.unwrap_or(u_dummy_native.clone()))
-        })?;
-        let U_i1 = CommittedInstanceInCycleFoldVar::<C, GC>::new_witness(cs.clone(), || {
-            Ok(self.U_i1.unwrap_or(u_dummy_native.clone()))
-        })?;
         let _x = Vec::<FpVar<CF2<C>>>::new_input(cs.clone(), || {
             Ok(self.x.unwrap_or(vec![CF2::<C>::zero(); CF_IO_LEN]))
         })?;
         #[cfg(test)]
         assert_eq!(_x.len(), CF_IO_LEN); // non-constrained sanity check
 
-        // fold the original Nova instances natively in CycleFold
-        let v =
-            NIFSinCycleFoldGadget::<C, GC>::verify(r_bits.clone(), cmT, u_i.clone(), U_i, U_i1)?;
-        v.enforce_equal(&Boolean::TRUE)?;
+        // Fold the original Nova instances natively in CycleFold
+        // For the cmW we're checking: U_i1.cmW == U_i.cmW + r * u_i.cmW
+        // For the cmE we're checking: U_i1.cmE == U_i.cmE + r * cmT + r^2 * u_i.cmE, where u_i.cmE
+        // is assumed to be 0, so, U_i1.cmE == U_i.cmE + r * cmT
+        p3.enforce_equal(&(p1 + p2.scalar_mul_le(r_bits.iter())?))?;
 
         // check that x == [u_i, U_i, U_{i+1}], check that the cmW & cmW from u_i, U_i, U_{i+1} in
         // the CycleFoldCircuit are the sames used in the public inputs 'x', which come from the
@@ -401,6 +391,7 @@ pub mod tests {
     use ark_relations::r1cs::ConstraintSystem;
     use ark_std::UniformRand;
 
+    use crate::folding::nova::get_cm_coordinates;
     use crate::folding::nova::nifs::tests::prepare_simple_fold_inputs;
     use crate::transcript::poseidon::poseidon_test_config;
 
@@ -426,6 +417,36 @@ pub mod tests {
         assert_eq!(ciVar.cmW.value().unwrap(), ci.cmW);
     }
 
+    #[test]
+    fn test_CycleFoldCircuit_constraints() {
+        let (_, _, _, _, ci1, _, ci2, _, ci3, _, cmT, r_bits, _) = prepare_simple_fold_inputs();
+
+        // cs is the Constraint System on the Curve Cycle auxiliary curve constraints field
+        // (E2::Fr)
+        let cs = ConstraintSystem::<Fq>::new_ref();
+
+        // let r_bitsVar = Vec::<Boolean<Fq>>::new_witness(cs.clone(), || Ok(r_bits)).unwrap();
+
+        let cfW_u_i_x = [
+            get_cm_coordinates(&ci1.cmW),
+            get_cm_coordinates(&ci2.cmW),
+            get_cm_coordinates(&ci3.cmW),
+        ]
+        .concat();
+        // let cmTVar = GVar::new_witness(cs.clone(), || Ok(cmT)).unwrap();
+        let cfW_circuit = CycleFoldCircuit::<Projective, GVar> {
+            _gc: PhantomData,
+            r_bits: Some(r_bits.clone()),
+            p1: Some(ci1.clone().cmW),
+            p2: Some(ci2.clone().cmW),
+            p3: Some(ci3.clone().cmW),
+            x: Some(cfW_u_i_x.clone()),
+        };
+        cfW_circuit.generate_constraints(cs.clone()).unwrap();
+        assert!(cs.is_satisfied().unwrap());
+        dbg!(cs.num_constraints());
+    }
+    /*
     #[test]
     fn test_nifs_gadget_cyclefold() {
         let (_, _, _, _, ci1, _, ci2, _, ci3, _, cmT, r_bits, _) = prepare_simple_fold_inputs();
@@ -460,6 +481,7 @@ pub mod tests {
         nifs_cf_check.enforce_equal(&Boolean::<Fq>::TRUE).unwrap();
         assert!(cs.is_satisfied().unwrap());
     }
+    */
 
     #[test]
     fn test_nifs_full_gadget() {
@@ -527,8 +549,8 @@ pub mod tests {
         // compute the challenge natively
         let r_bits = CycleFoldChallengeGadget::<Projective, GVar>::get_challenge_native(
             &poseidon_config,
-            u_i.clone(),
             U_i.clone(),
+            u_i.clone(),
             cmT,
         )
         .unwrap();
@@ -549,8 +571,8 @@ pub mod tests {
         let r_bitsVar = CycleFoldChallengeGadget::<Projective, GVar>::get_challenge_gadget(
             cs.clone(),
             &poseidon_config,
-            u_iVar,
             U_iVar,
+            u_iVar,
             cmTVar,
         )
         .unwrap();

--- a/folding-schemes/src/folding/nova/cyclefold.rs
+++ b/folding-schemes/src/folding/nova/cyclefold.rs
@@ -173,6 +173,7 @@ where
     for<'a> &'a GC: GroupOpsBounds<'a, C, GC>,
 {
     pub fn verify(
+        // assumes that r_bits is equal to r_nonnat just that in a different format
         r_bits: Vec<Boolean<CF2<C>>>,
         r_nonnat: NonNativeFieldVar<C::ScalarField, CF2<C>>,
         cmT: GC,

--- a/folding-schemes/src/folding/nova/cyclefold.rs
+++ b/folding-schemes/src/folding/nova/cyclefold.rs
@@ -122,42 +122,6 @@ where
     }
 }
 
-/*
-/// NIFSinCycleFoldGadget performs the Nova NIFS.V elliptic curve points relation checks in the other
-/// curve (natively) following [CycleFold](https://eprint.iacr.org/2023/1192.pdf).
-pub struct NIFSinCycleFoldGadget<C: CurveGroup, GC: CurveVar<C, CF2<C>>> {
-    _c: PhantomData<C>,
-    _gc: PhantomData<GC>,
-}
-impl<C: CurveGroup, GC: CurveVar<C, CF2<C>>> NIFSinCycleFoldGadget<C, GC>
-where
-    C: CurveGroup,
-    GC: CurveVar<C, CF2<C>>,
-    <C as ark_ec::CurveGroup>::BaseField: ark_ff::PrimeField,
-    for<'a> &'a GC: GroupOpsBounds<'a, C, GC>,
-{
-    pub fn verify(
-        r_bits: Vec<Boolean<CF2<C>>>,
-        cmT: GC,
-        ci1: CommittedInstanceInCycleFoldVar<C, GC>,
-        ci2: CommittedInstanceInCycleFoldVar<C, GC>,
-        ci3: CommittedInstanceInCycleFoldVar<C, GC>,
-    ) -> Result<Boolean<CF2<C>>, SynthesisError> {
-        // cm(E) check: ci3.cmE == ci1.cmE + r * cmT + r^2 * ci2.cmE
-        let first_check = ci3.cmE.is_eq(
-            &((ci2.cmE.scalar_mul_le(r_bits.iter())? + cmT).scalar_mul_le(r_bits.iter())?
-                + ci1.cmE),
-        )?;
-        // cm(W) check: ci3.cmW == ci1.cmW + r * ci2.cmW
-        let second_check = ci3
-            .cmW
-            .is_eq(&(ci1.cmW + ci2.cmW.scalar_mul_le(r_bits.iter())?))?;
-
-        first_check.and(&second_check)
-    }
-}
-*/
-
 /// This is the gadget used in the AugmentedFCircuit to verify the CycleFold instances folding,
 /// which checks the correct RLC of u,x,cmE,cmW (hence the name containing 'Full', since it checks
 /// all the RLC values, not only the native ones). It assumes that ci2.cmE=0, ci2.u=1.
@@ -233,11 +197,11 @@ where
     ) -> Result<Vec<bool>, Error> {
         let mut sponge = PoseidonSponge::<C::BaseField>::new(poseidon_config);
 
-        let U_i_cmE_bytes = point_to_bytes(U_i.cmE);
-        let U_i_cmW_bytes = point_to_bytes(U_i.cmW);
-        let u_i_cmE_bytes = point_to_bytes(u_i.cmE);
-        let u_i_cmW_bytes = point_to_bytes(u_i.cmW);
-        let cmT_bytes = point_to_bytes(cmT);
+        let U_i_cmE_bytes = point_to_bytes(U_i.cmE)?;
+        let U_i_cmW_bytes = point_to_bytes(U_i.cmW)?;
+        let u_i_cmE_bytes = point_to_bytes(u_i.cmE)?;
+        let u_i_cmW_bytes = point_to_bytes(u_i.cmW)?;
+        let cmT_bytes = point_to_bytes(cmT)?;
 
         let mut U_i_u_bytes = Vec::new();
         U_i.u.serialize_uncompressed(&mut U_i_u_bytes)?;
@@ -310,16 +274,16 @@ where
 }
 
 /// returns the bytes being compatible with the ark_r1cs_std `.to_bytes` approach
-fn point_to_bytes<C: CurveGroup>(p: C) -> Vec<u8> {
+fn point_to_bytes<C: CurveGroup>(p: C) -> Result<Vec<u8>, Error> {
     let l = p.uncompressed_size();
     let mut b = Vec::new();
-    p.serialize_uncompressed(&mut b).unwrap();
+    p.serialize_uncompressed(&mut b)?;
     b[l - 1] = 0;
     if p.is_zero() {
         b[l / 2] = 1;
         b[l - 1] = 1;
     }
-    b
+    Ok(b)
 }
 
 /// CycleFoldCircuit contains the constraints that check the correct fold of the committed
@@ -423,10 +387,8 @@ pub mod tests {
         let (_, _, _, _, ci1, _, ci2, _, ci3, _, cmT, r_bits, _) = prepare_simple_fold_inputs();
 
         // cs is the Constraint System on the Curve Cycle auxiliary curve constraints field
-        // (E2::Fr)
+        // (E1::Fq=E2::Fr)
         let cs = ConstraintSystem::<Fq>::new_ref();
-
-        // let r_bitsVar = Vec::<Boolean<Fq>>::new_witness(cs.clone(), || Ok(r_bits)).unwrap();
 
         let cfW_u_i_x = [
             get_cm_coordinates(&ci1.cmW),
@@ -434,7 +396,6 @@ pub mod tests {
             get_cm_coordinates(&ci3.cmW),
         ]
         .concat();
-        // let cmTVar = GVar::new_witness(cs.clone(), || Ok(cmT)).unwrap();
         let cfW_circuit = CycleFoldCircuit::<Projective, GVar> {
             _gc: PhantomData,
             r_bits: Some(r_bits.clone()),
@@ -446,43 +407,26 @@ pub mod tests {
         cfW_circuit.generate_constraints(cs.clone()).unwrap();
         assert!(cs.is_satisfied().unwrap());
         dbg!(cs.num_constraints());
-    }
-    /*
-    #[test]
-    fn test_nifs_gadget_cyclefold() {
-        let (_, _, _, _, ci1, _, ci2, _, ci3, _, cmT, r_bits, _) = prepare_simple_fold_inputs();
 
-        // cs is the Constraint System on the Curve Cycle auxiliary curve constraints field
-        // (E2::Fr)
+        // same for E:
         let cs = ConstraintSystem::<Fq>::new_ref();
-
-        let r_bitsVar = Vec::<Boolean<Fq>>::new_witness(cs.clone(), || Ok(r_bits)).unwrap();
-
-        let cmTVar = GVar::new_witness(cs.clone(), || Ok(cmT)).unwrap();
-        let ci1Var =
-            CommittedInstanceInCycleFoldVar::<Projective, GVar>::new_witness(cs.clone(), || {
-                Ok(ci1.clone())
-            })
-            .unwrap();
-        let ci2Var =
-            CommittedInstanceInCycleFoldVar::<Projective, GVar>::new_witness(cs.clone(), || {
-                Ok(ci2.clone())
-            })
-            .unwrap();
-        let ci3Var =
-            CommittedInstanceInCycleFoldVar::<Projective, GVar>::new_witness(cs.clone(), || {
-                Ok(ci3.clone())
-            })
-            .unwrap();
-
-        let nifs_cf_check = NIFSinCycleFoldGadget::<Projective, GVar>::verify(
-            r_bitsVar, cmTVar, ci1Var, ci2Var, ci3Var,
-        )
-        .unwrap();
-        nifs_cf_check.enforce_equal(&Boolean::<Fq>::TRUE).unwrap();
+        let cfE_u_i_x = [
+            get_cm_coordinates(&ci1.cmE),
+            get_cm_coordinates(&ci2.cmE),
+            get_cm_coordinates(&ci3.cmE),
+        ]
+        .concat();
+        let cfE_circuit = CycleFoldCircuit::<Projective, GVar> {
+            _gc: PhantomData,
+            r_bits: Some(r_bits.clone()),
+            p1: Some(ci1.clone().cmE),
+            p2: Some(cmT),
+            p3: Some(ci3.clone().cmE),
+            x: Some(cfE_u_i_x.clone()),
+        };
+        cfE_circuit.generate_constraints(cs.clone()).unwrap();
         assert!(cs.is_satisfied().unwrap());
     }
-    */
 
     #[test]
     fn test_nifs_full_gadget() {

--- a/folding-schemes/src/folding/nova/decider_eth.rs
+++ b/folding-schemes/src/folding/nova/decider_eth.rs
@@ -68,9 +68,7 @@ where
         let circuit =
             DeciderEthCircuit::<C1, GC1, C2, GC2, CP1, CP2>::from_nova::<FC>(folding_scheme.into());
 
-        let proof = S::prove(pp, circuit.clone(), &mut rng).unwrap();
-
-        Ok(proof)
+        S::prove(pp, circuit.clone(), &mut rng).map_err(|e| Error::Other(e.to_string()))
     }
 
     fn verify(

--- a/folding-schemes/src/folding/nova/decider_eth_circuit.rs
+++ b/folding-schemes/src/folding/nova/decider_eth_circuit.rs
@@ -367,6 +367,7 @@ where
             // `#[cfg(not(test))]`
             use crate::commitment::pedersen::PedersenGadget;
             use crate::folding::nova::cyclefold::{CycleFoldCommittedInstanceVar, CF_IO_LEN};
+            use ark_r1cs_std::ToBitsGadget;
 
             let cf_u_dummy_native = CommittedInstance::<C2>::dummy(CF_IO_LEN);
             let w_dummy_native = Witness::<C2>::new(

--- a/folding-schemes/src/folding/nova/decider_eth_circuit.rs
+++ b/folding-schemes/src/folding/nova/decider_eth_circuit.rs
@@ -645,14 +645,14 @@ pub mod tests {
             r1cs: ivc_v.clone().r1cs,
             cf_r1cs: ivc_v.clone().cf_r1cs,
         };
-        let (running_instance, incomming_instance, cyclefold_instance) = ivc_v.instances();
+        let (running_instance, incoming_instance, cyclefold_instance) = ivc_v.instances();
         NOVA::verify(
             verifier_params,
             z_0,
             ivc_v.z_i,
             Fr::one(),
             running_instance,
-            incomming_instance,
+            incoming_instance,
             cyclefold_instance,
         )
         .unwrap();

--- a/folding-schemes/src/folding/nova/decider_eth_circuit.rs
+++ b/folding-schemes/src/folding/nova/decider_eth_circuit.rs
@@ -242,7 +242,7 @@ where
             _cp2: PhantomData,
 
             E_len: nova.W_i.E.len(),
-            cf_E_len: nova.cf_W_i.E.len(),
+            cf_E_len: nova.cfE_W_i.E.len(),
             r1cs: nova.r1cs,
             cf_r1cs: nova.cf_r1cs,
             cf_pedersen_params: nova.cf_cm_params,
@@ -254,8 +254,8 @@ where
             w_i: Some(nova.w_i),
             U_i: Some(nova.U_i),
             W_i: Some(nova.W_i),
-            cf_U_i: Some(nova.cf_U_i),
-            cf_W_i: Some(nova.cf_W_i),
+            cf_U_i: Some(nova.cfW_U_i), // TODO merge cfW & cfE
+            cf_W_i: Some(nova.cfW_W_i),
         }
     }
 }
@@ -641,17 +641,18 @@ pub mod tests {
         let ivc_v = nova.clone();
         let verifier_params = VerifierParams::<Projective, Projective2> {
             poseidon_config: poseidon_config.clone(),
-            r1cs: ivc_v.r1cs,
-            cf_r1cs: ivc_v.cf_r1cs,
+            r1cs: ivc_v.clone().r1cs,
+            cf_r1cs: ivc_v.clone().cf_r1cs,
         };
+        let (running_instance, incomming_instance, cyclefold_instance) = ivc_v.instances();
         NOVA::verify(
             verifier_params,
             z_0,
             ivc_v.z_i,
             Fr::one(),
-            (ivc_v.U_i, ivc_v.W_i),
-            (ivc_v.u_i, ivc_v.w_i),
-            (ivc_v.cf_U_i, ivc_v.cf_W_i),
+            running_instance,
+            incomming_instance,
+            cyclefold_instance,
         )
         .unwrap();
 

--- a/folding-schemes/src/folding/nova/decider_eth_circuit.rs
+++ b/folding-schemes/src/folding/nova/decider_eth_circuit.rs
@@ -242,7 +242,7 @@ where
             _cp2: PhantomData,
 
             E_len: nova.W_i.E.len(),
-            cf_E_len: nova.cfE_W_i.E.len(),
+            cf_E_len: nova.cf_W_i.E.len(),
             r1cs: nova.r1cs,
             cf_r1cs: nova.cf_r1cs,
             cf_pedersen_params: nova.cf_cm_params,
@@ -254,8 +254,8 @@ where
             w_i: Some(nova.w_i),
             U_i: Some(nova.U_i),
             W_i: Some(nova.W_i),
-            cf_U_i: Some(nova.cfW_U_i), // TODO merge cfW & cfE
-            cf_W_i: Some(nova.cfW_W_i),
+            cf_U_i: Some(nova.cf_U_i),
+            cf_W_i: Some(nova.cf_W_i),
         }
     }
 }
@@ -344,13 +344,11 @@ where
         let zero_x = NonNativeFieldVar::<C1::BaseField, C1::ScalarField>::new_constant(
             cs.clone(),
             C1::BaseField::zero(),
-        )?
-        .to_constraint_field()?;
+        )?;
         let zero_y = NonNativeFieldVar::<C1::BaseField, C1::ScalarField>::new_constant(
             cs.clone(),
             C1::BaseField::one(),
-        )?
-        .to_constraint_field()?;
+        )?;
         (u_i.cmE.x.is_eq(&zero_x)?).enforce_equal(&Boolean::TRUE)?;
         (u_i.cmE.y.is_eq(&zero_y)?).enforce_equal(&Boolean::TRUE)?;
         (u_i.u.is_one()?).enforce_equal(&Boolean::TRUE)?;

--- a/folding-schemes/src/folding/nova/mod.rs
+++ b/folding-schemes/src/folding/nova/mod.rs
@@ -385,10 +385,8 @@ where
                 x: Some(cfE_u_i_x.clone()),
             };
 
-            // TODO cfW_w_i & cfW_r_bits are not needed to be returned
-
             // fold self.cf_U_i + cfW_U -> folded running with cfW
-            let (cfW_w_i, cfW_u_i, cfW_W_i1, cfW_U_i1, cfW_cmT, cfW_r1_Fq, cfW_r_bits) = self
+            let (_cfW_w_i, cfW_u_i, cfW_W_i1, cfW_U_i1, cfW_cmT, cfW_r1_Fq) = self
                 .fold_cyclefold_circuit(
                     self.cf_W_i.clone(), // CycleFold running instance witness
                     self.cf_U_i.clone(), // CycleFold running instance
@@ -396,7 +394,7 @@ where
                     cfW_circuit,
                 )?;
             // fold [the output from folding self.cf_U_i + cfW_U] + cfE_U = folded_running_with_cfW + cfE
-            let (cfE_w_i, cfE_u_i, cf_W_i1, cf_U_i1, cf_cmT, cf_r2_Fq, cf_r_bits) =
+            let (_cfE_w_i, cfE_u_i, cf_W_i1, cf_U_i1, cf_cmT, cf_r2_Fq) =
                 self.fold_cyclefold_circuit(cfW_W_i1, cfW_U_i1.clone(), cfE_u_i_x, cfE_circuit)?;
 
             augmented_F_circuit = AugmentedFCircuit::<C1, C2, GC2, FC> {
@@ -428,8 +426,8 @@ where
 
             #[cfg(test)]
             {
-                self.cf_r1cs.check_instance_relation(&cfW_w_i, &cfW_u_i)?;
-                self.cf_r1cs.check_instance_relation(&cfE_w_i, &cfE_u_i)?;
+                self.cf_r1cs.check_instance_relation(&_cfW_w_i, &cfW_u_i)?;
+                self.cf_r1cs.check_instance_relation(&_cfE_w_i, &cfE_u_i)?;
                 self.cf_r1cs
                     .check_relaxed_instance_relation(&self.cf_W_i, &self.cf_U_i)?;
             }
@@ -599,12 +597,11 @@ where
     ) -> Result<
         (
             Witness<C2>,
-            CommittedInstance<C2>,
-            Witness<C2>,
-            CommittedInstance<C2>,
-            C2,
-            C2::ScalarField,
-            Vec<bool>,
+            CommittedInstance<C2>, // u_i
+            Witness<C2>,           // W_i1
+            CommittedInstance<C2>, // U_i1
+            C2,                    // cmT
+            C2::ScalarField,       // r_Fq
         ),
         Error,
     > {
@@ -642,7 +639,7 @@ where
         let (cf_W_i1, cf_U_i1) = NIFS::<C2, CP2>::fold_instances(
             cf_r_Fq, &cf_W_i, &cf_U_i, &cf_w_i, &cf_u_i, &cf_T, cf_cmT,
         )?;
-        Ok((cf_w_i, cf_u_i, cf_W_i1, cf_U_i1, cf_cmT, cf_r_Fq, cf_r_bits))
+        Ok((cf_w_i, cf_u_i, cf_W_i1, cf_U_i1, cf_cmT, cf_r_Fq))
     }
 }
 

--- a/folding-schemes/src/folding/nova/mod.rs
+++ b/folding-schemes/src/folding/nova/mod.rs
@@ -460,11 +460,9 @@ where
 
         #[cfg(test)]
         {
-            dbg!("pre check r1cs");
             self.r1cs.check_instance_relation(&self.w_i, &self.u_i)?;
             self.r1cs
                 .check_relaxed_instance_relation(&self.W_i, &self.U_i)?;
-            dbg!("post check r1cs");
         }
 
         Ok(())

--- a/folding-schemes/src/folding/nova/mod.rs
+++ b/folding-schemes/src/folding/nova/mod.rs
@@ -249,13 +249,11 @@ where
 
         augmented_F_circuit.generate_constraints(cs.clone())?;
         cs.finalize();
-        dbg!(cs.num_constraints());
         let cs = cs.into_inner().ok_or(Error::NoInnerConstraintSystem)?;
         let r1cs = extract_r1cs::<C1::ScalarField>(&cs);
 
         cf_circuit.generate_constraints(cs2.clone())?;
         cs2.finalize();
-        dbg!(cs2.num_constraints());
         let cs2 = cs2.into_inner().ok_or(Error::NoInnerConstraintSystem)?;
         let cf_r1cs = extract_r1cs::<C1::BaseField>(&cs2);
 
@@ -764,8 +762,7 @@ pub mod tests {
         let mut nova = NOVA::init(&prover_params, F_circuit, z_0.clone()).unwrap();
 
         let num_steps: usize = 3;
-        for i in 0..num_steps {
-            dbg!(i);
+        for _ in 0..num_steps {
             nova.prove_step().unwrap();
         }
         assert_eq!(Fr::from(num_steps as u32), nova.i);

--- a/folding-schemes/src/folding/nova/mod.rs
+++ b/folding-schemes/src/folding/nova/mod.rs
@@ -193,10 +193,8 @@ where
     pub U_i: CommittedInstance<C1>,
 
     /// CycleFold running instance
-    pub cfW_W_i: Witness<C2>,
-    pub cfW_U_i: CommittedInstance<C2>,
-    pub cfE_W_i: Witness<C2>,
-    pub cfE_U_i: CommittedInstance<C2>,
+    pub cf_W_i: Witness<C2>,
+    pub cf_U_i: CommittedInstance<C2>,
 }
 
 impl<C1, GC1, C2, GC2, FC, CP1, CP2> FoldingScheme<C1, C2, FC>
@@ -221,12 +219,7 @@ where
     type ProverParam = ProverParams<C1, C2, CP1, CP2>;
     type VerifierParam = VerifierParams<C1, C2>;
     type CommittedInstanceWithWitness = (CommittedInstance<C1>, Witness<C1>);
-    type CFCommittedInstanceWithWitness = (
-        CommittedInstance<C2>,
-        Witness<C2>,
-        CommittedInstance<C2>,
-        Witness<C2>,
-    );
+    type CFCommittedInstanceWithWitness = (CommittedInstance<C2>, Witness<C2>);
 
     fn preprocess(
         prep_param: &Self::PreprocessorParam,
@@ -290,10 +283,8 @@ where
             W_i: w_dummy,
             U_i: u_dummy,
             // cyclefold running instance
-            cfW_W_i: cf_w_dummy.clone(),
-            cfW_U_i: cf_u_dummy.clone(),
-            cfE_W_i: cf_w_dummy.clone(),
-            cfE_U_i: cf_u_dummy.clone(),
+            cf_W_i: cf_w_dummy.clone(),
+            cf_U_i: cf_u_dummy.clone(),
         })
     }
 
@@ -346,16 +337,15 @@ where
                 cmT: Some(cmT),
                 F: self.F,
                 x: Some(u_i1_x),
-                cfW_u_i: None,
-                cfW_U_i: None,
-                cfW_U_i1: None,
-                cfW_cmT: None,
-                cfW_r_nonnat: None,
-                cfE_u_i: None,
-                cfE_U_i: None,
-                cfE_U_i1: None,
-                cfE_cmT: None,
-                cfE_r_nonnat: None,
+                cf1_u_i: None,
+                cf2_u_i: None,
+                cf_U_i: None,
+                cf1_U_i1: None,
+                cf_U_i1: None,
+                cf1_cmT: None,
+                cf2_cmT: None,
+                cf1_r_nonnat: None,
+                cf2_r_nonnat: None,
             };
 
             #[cfg(test)]
@@ -395,22 +385,19 @@ where
                 x: Some(cfE_u_i_x.clone()),
             };
 
-            // TODO maybe cfW_w_i & cfW_r_bits are not needed to be returned
-            // cf{W,E}_r_bits is the r used to the RLC of the CycleFold circuit instances
-            let (cfW_w_i, cfW_u_i, cfW_W_i1, cfW_U_i1, cfW_cmT, cfW_r_Fq, cfW_r_bits) = self
+            // TODO cfW_w_i & cfW_r_bits are not needed to be returned
+
+            // fold self.cf_U_i + cfW_U -> folded running with cfW
+            let (cfW_w_i, cfW_u_i, cfW_W_i1, cfW_U_i1, cfW_cmT, cfW_r1_Fq, cfW_r_bits) = self
                 .fold_cyclefold_circuit(
-                    self.cfW_W_i.clone(), // CycleFold running instance witness
-                    self.cfW_U_i.clone(), // CycleFold running instance
+                    self.cf_W_i.clone(), // CycleFold running instance witness
+                    self.cf_U_i.clone(), // CycleFold running instance
                     cfW_u_i_x,
                     cfW_circuit,
                 )?;
-            let (cfE_w_i, cfE_u_i, cfE_W_i1, cfE_U_i1, cfE_cmT, cfE_r_Fq, cfE_r_bits) = self
-                .fold_cyclefold_circuit(
-                    self.cfE_W_i.clone(),
-                    self.cfE_U_i.clone(),
-                    cfE_u_i_x,
-                    cfE_circuit,
-                )?;
+            // fold [the output from folding self.cf_U_i + cfW_U] + cfE_U = folded_running_with_cfW + cfE
+            let (cfE_w_i, cfE_u_i, cf_W_i1, cf_U_i1, cf_cmT, cf_r2_Fq, cf_r_bits) =
+                self.fold_cyclefold_circuit(cfW_W_i1, cfW_U_i1.clone(), cfE_u_i_x, cfE_circuit)?;
 
             augmented_F_circuit = AugmentedFCircuit::<C1, C2, GC2, FC> {
                 _gc2: PhantomData,
@@ -425,31 +412,26 @@ where
                 F: self.F,
                 x: Some(u_i1_x),
                 // cyclefold values
-                cfW_u_i: Some(cfW_u_i.clone()),
-                cfW_U_i: Some(self.cfW_U_i.clone()),
-                cfW_U_i1: Some(cfW_U_i1.clone()),
-                cfW_cmT: Some(cfW_cmT),
-                cfW_r_nonnat: Some(cfW_r_Fq),
-                cfE_u_i: Some(cfE_u_i.clone()),
-                cfE_U_i: Some(self.cfE_U_i.clone()),
-                cfE_U_i1: Some(cfE_U_i1.clone()),
-                cfE_cmT: Some(cfE_cmT),
-                cfE_r_nonnat: Some(cfE_r_Fq),
+                cf1_u_i: Some(cfW_u_i.clone()),
+                cf2_u_i: Some(cfE_u_i.clone()),
+                cf_U_i: Some(self.cf_U_i.clone()),
+                cf1_U_i1: Some(cfW_U_i1.clone()),
+                cf_U_i1: Some(cf_U_i1.clone()),
+                cf1_cmT: Some(cfW_cmT),
+                cf2_cmT: Some(cf_cmT),
+                cf1_r_nonnat: Some(cfW_r1_Fq),
+                cf2_r_nonnat: Some(cf_r2_Fq),
             };
 
-            self.cfW_W_i = cfW_W_i1.clone();
-            self.cfW_U_i = cfW_U_i1.clone();
-            self.cfE_W_i = cfE_W_i1.clone();
-            self.cfE_U_i = cfE_U_i1.clone();
+            self.cf_W_i = cf_W_i1.clone();
+            self.cf_U_i = cf_U_i1.clone();
 
             #[cfg(test)]
             {
                 self.cf_r1cs.check_instance_relation(&cfW_w_i, &cfW_u_i)?;
+                self.cf_r1cs.check_instance_relation(&cfE_w_i, &cfE_u_i)?;
                 self.cf_r1cs
-                    .check_relaxed_instance_relation(&self.cfW_W_i, &self.cfW_U_i)?;
-                self.cf_r1cs.check_instance_relation(&cfE_w_i, &cfE_u_i)?; // TODO uncomment once ready
-                self.cf_r1cs
-                    .check_relaxed_instance_relation(&self.cfE_W_i, &self.cfE_U_i)?;
+                    .check_relaxed_instance_relation(&self.cf_W_i, &self.cf_U_i)?;
             }
         }
 
@@ -478,9 +460,11 @@ where
 
         #[cfg(test)]
         {
+            dbg!("pre check r1cs");
             self.r1cs.check_instance_relation(&self.w_i, &self.u_i)?;
             self.r1cs
                 .check_relaxed_instance_relation(&self.W_i, &self.U_i)?;
+            dbg!("post check r1cs");
         }
 
         Ok(())
@@ -499,12 +483,7 @@ where
         (
             (self.U_i.clone(), self.W_i.clone()),
             (self.u_i.clone(), self.w_i.clone()),
-            (
-                self.cfW_U_i.clone(),
-                self.cfW_W_i.clone(),
-                self.cfE_U_i.clone(),
-                self.cfE_W_i.clone(),
-            ),
+            (self.cf_U_i.clone(), self.cf_W_i.clone()),
         )
     }
 
@@ -520,7 +499,7 @@ where
     ) -> Result<(), Error> {
         let (U_i, W_i) = running_instance;
         let (u_i, w_i) = incoming_instance;
-        let (cfW_U_i, cfW_W_i, cfE_U_i, cfE_W_i) = cyclefold_instance;
+        let (cf_U_i, cf_W_i) = cyclefold_instance;
 
         if u_i.x.len() != 1 || U_i.x.len() != 1 {
             return Err(Error::IVCVerificationFail);
@@ -545,9 +524,7 @@ where
 
         // check CycleFold RelaxedR1CS satisfiability
         vp.cf_r1cs
-            .check_relaxed_instance_relation(&cfW_W_i, &cfW_U_i)?;
-        vp.cf_r1cs
-            .check_relaxed_instance_relation(&cfE_W_i, &cfE_U_i)?;
+            .check_relaxed_instance_relation(&cf_W_i, &cf_U_i)?;
 
         Ok(())
     }
@@ -617,8 +594,8 @@ where
     // folds the given cyclefold circuit and its instances
     fn fold_cyclefold_circuit(
         &self,
-        cf_W_i: Witness<C2>,
-        cf_U_i: CommittedInstance<C2>,
+        cf_W_i: Witness<C2>,           // witness of the running instance
+        cf_U_i: CommittedInstance<C2>, // running instance
         cf_u_i_x: Vec<C2::ScalarField>,
         cf_circuit: CycleFoldCircuit<C1, GC1>,
     ) -> Result<
@@ -741,18 +718,6 @@ pub(crate) fn get_cm_coordinates<C: CurveGroup>(cm: &C) -> Vec<C::BaseField> {
     let (cm_x, cm_y) = cm.xy().unwrap_or(zero);
     vec![*cm_x, *cm_y]
 }
-// pub(crate) fn get_committed_instance_coordinates<C: CurveGroup>(
-//     u: &CommittedInstance<C>,
-// ) -> Vec<C::BaseField> {
-//     let zero = (&C::BaseField::zero(), &C::BaseField::one());
-//
-//     let cmE = u.cmE.into_affine();
-//     let (cmE_x, cmE_y) = cmE.xy().unwrap_or(zero);
-//
-//     let cmW = u.cmW.into_affine();
-//     let (cmW_x, cmW_y) = cmW.xy().unwrap_or(zero);
-//     vec![*cmE_x, *cmE_y, *cmW_x, *cmW_y]
-// }
 
 #[cfg(test)]
 pub mod tests {

--- a/folding-schemes/src/folding/nova/mod.rs
+++ b/folding-schemes/src/folding/nova/mod.rs
@@ -564,8 +564,8 @@ where
             &self.cf_r1cs,
             cf_w_i,
             cf_u_i,
-            &cf_W_i,
-            &cf_U_i,
+            cf_W_i,
+            cf_U_i,
         )
     }
 }
@@ -588,6 +588,7 @@ where
     for<'a> &'a GC2: GroupOpsBounds<'a, C2, GC2>,
 {
     // folds the given cyclefold circuit and its instances
+    #[allow(clippy::type_complexity)]
     fn fold_cyclefold_circuit(
         &self,
         cf_W_i: Witness<C2>,           // witness of the running instance
@@ -724,6 +725,8 @@ pub mod tests {
     use crate::frontend::tests::CubicFCircuit;
     use crate::transcript::poseidon::poseidon_test_config;
 
+    /// This test tests the Nova+CycleFold IVC, and by consequence it is also testing the
+    /// AugmentedFCircuit
     #[test]
     fn test_ivc() {
         type NOVA = Nova<

--- a/folding-schemes/src/folding/nova/mod.rs
+++ b/folding-schemes/src/folding/nova/mod.rs
@@ -772,14 +772,14 @@ pub mod tests {
             r1cs: nova.clone().r1cs,
             cf_r1cs: nova.clone().cf_r1cs,
         };
-        let (running_instance, incomming_instance, cyclefold_instance) = nova.instances();
+        let (running_instance, incoming_instance, cyclefold_instance) = nova.instances();
         NOVA::verify(
             verifier_params,
             z_0,
             nova.z_i,
             nova.i,
             running_instance,
-            incomming_instance,
+            incoming_instance,
             cyclefold_instance,
         )
         .unwrap();

--- a/folding-schemes/src/folding/nova/nifs.rs
+++ b/folding-schemes/src/folding/nova/nifs.rs
@@ -68,8 +68,8 @@ where
 
     pub fn fold_committed_instance(
         r: C::ScalarField,
-        ci1: &CommittedInstance<C>,
-        ci2: &CommittedInstance<C>,
+        ci1: &CommittedInstance<C>, // U_i
+        ci2: &CommittedInstance<C>, // u_i
         cmT: &C,
     ) -> CommittedInstance<C> {
         let r2 = r * r;

--- a/folding-schemes/src/lib.rs
+++ b/folding-schemes/src/lib.rs
@@ -105,7 +105,7 @@ where
     fn state(&self) -> Vec<C1::ScalarField>;
 
     // returns the instances at the current step, in the following order:
-    // (running_instance, incomming_instance, cyclefold_instance)
+    // (running_instance, incoming_instance, cyclefold_instance)
     fn instances(
         &self,
     ) -> (

--- a/folding-schemes/src/lib.rs
+++ b/folding-schemes/src/lib.rs
@@ -104,7 +104,8 @@ where
     // returns the state at the current step
     fn state(&self) -> Vec<C1::ScalarField>;
 
-    // returns the instances at the current step
+    // returns the instances at the current step, in the following order:
+    // (running_instance, incomming_instance, cyclefold_instance)
     fn instances(
         &self,
     ) -> (

--- a/folding-schemes/src/utils/gadgets.rs
+++ b/folding-schemes/src/utils/gadgets.rs
@@ -15,6 +15,11 @@ pub fn mat_vec_mul_sparse<F: PrimeField, CF: PrimeField, FV: FieldVar<F, CF>>(
     let mut res = vec![FV::zero(); m.n_rows];
     for (row_i, row) in m.coeffs.iter().enumerate() {
         for (value, col_i) in row.iter() {
+            if value.value().unwrap() == F::one() {
+                // no need to multiply by 1
+                res[row_i] += v[*col_i].clone();
+                continue;
+            }
             res[row_i] += value.clone().mul(&v[*col_i].clone());
         }
     }


### PR DESCRIPTION
Spoke last week with @mpenciak and @adr1anh from @lurk-lab, and they mentioned the approach they were using for the CycleFold circuit, and it makes a lot of sense for us too, since we're interested in the Ethereum onchain verification use case.

The main idea is that for the CycleFold circuit, instead of having a CycleFold circuit that verifies the folding of the cmE & cmW all-together (so, 2 scalar muls in the circuit), we can have 2 separated CycleFold circuits which each one does only one of each cmE & cmW (so 1 single scalar mul per circuit), and then plug them into the main nova AugmentedFCircuit, and then at each step we fold the two CycleFold circuits into a single instance.

This comes with the increase the AugmentedFCircuit number of constraints (this is not the good part) but we reduce the CycleFold circuit from ~4000 constraints into a bit more than 1400 constraints.
And this is great because verifying the CycleFold circuit RelaxedR1CS relation in the Decider circuit is what takes most of the number of constraints, so with this the number of constraints in the Decider circuit will go down notably on that part.
And furthermore, this is also great because another big part of the constraints of the Decider circuit were to verify the commitment of the cyclefold cmE & cmW (each one a MSM of ~4k), which now has halved in size, requiring half of the constraints to verify them in the Decider circuit.

This PR implements the described approach for the CycleFold circuit and Nova+CycleFold IVC and Decider.

<br>

Note, ~40% of the removed code lines are due the removal of the `test_augmented_f_circuit` test, which was checking the same that is tested in the `test_ivc`, and since is a slow test, decided to remove it (keeping the `test_ivc`).